### PR TITLE
DOC-7197: Remote link with alternate address fails if ports not mapped

### DIFF
--- a/src/analytics-links/extensions/dynamic/paths/post_link/operation-description-after-alt.md
+++ b/src/analytics-links/extensions/dynamic/paths/post_link/operation-description-after-alt.md
@@ -1,0 +1,6 @@
+When creating or altering a remote link using an alternate address, note the following:
+
+* At least one node in the remote cluster must expose the `mgmt` port (`rest_port`, default 8091) or the `mgmtSSL` port (`ssl_rest_port`, default 18091).
+* Furthermore, *all* data nodes in the remote cluster must expose the `kv` port (`memcached_port`, default 11210) or the `kvSSL` port (`memcached_ssl_port`, default 11207).
+
+Failure to do so will result in a 400 (Bad Request) error.

--- a/src/analytics-links/extensions/dynamic/paths/post_link/operation-description-after-alt.md
+++ b/src/analytics-links/extensions/dynamic/paths/post_link/operation-description-after-alt.md
@@ -4,3 +4,5 @@ When creating or altering a remote link using an alternate address, note the fol
 * Furthermore, *all* data nodes in the remote cluster must expose the `kv` port (`memcached_port`, default 11210) or the `kvSSL` port (`memcached_ssl_port`, default 11207).
 
 Failure to do so will result in a 400 (Bad Request) error.
+
+NOTE: The SSL ports are required when the **encryption** mode is set to `full`; the non-SSL ports are required otherwise.


### PR DESCRIPTION
Docs issue: [DOC-7197](https://issues.couchbase.com/browse/DOC-7197)