### PR TITLE
MB-42134: Update Link APIs docs to use 'scope' rather than 'dataverse'

### DIFF
--- a/src/analytics-links/extensions/spring/delete_link/http-request.md
+++ b/src/analytics-links/extensions/spring/delete_link/http-request.md
@@ -1,21 +1,25 @@
-The example below deletes the link named `myCbLink` from the `Default` dataverse.
+The example below deletes the link named `myCbLink` from the `travel-sample.inventory` scope.
 
 *Curl request*
 
 ``` shell
 $ curl -v -u Administrator:password \
        -X DELETE http://localhost:8095/analytics/link \
-       -d dataverse=Default \
+       -d scope='`travel-sample`.inventory' \
        -d name=myCbLink
 ```
 
-The example below deletes the link named `myAwsLink` from the `Default` dataverse.
+NOTE: The `scope` value is wrapped in single quotes to escape the backticks.
+
+The example below deletes the link named `myAwsLink` from the `travel-sample.inventory` scope.
 
 *Curl request*
 
 ``` shell
 $ curl -v -u Administrator:password \
        -X DELETE http://localhost:8095/analytics/link \
-       -d dataverse=Default \
+       -d scope='`travel-sample`.inventory' \
        -d name=myAwsLink
 ```
+
+NOTE: The `scope` value is wrapped in single quotes to escape the backticks.

--- a/src/analytics-links/extensions/spring/get_link/http-request.md
+++ b/src/analytics-links/extensions/spring/get_link/http-request.md
@@ -1,8 +1,10 @@
-The example below queries all links in the `Default` dataverse.
+The example below queries all links in the `travel-sample.inventory` scope.
 
 *Curl request*
 
 ``` shell
 $ curl -v -u Administrator:password \
-       http://localhost:8095/analytics/link?dataverse=Default
+       http://localhost:8095/analytics/link?scope='`travel-sample`.inventory'
 ```
+
+NOTE: The `scope` value is wrapped in single quotes to escape the backticks.

--- a/src/analytics-links/extensions/spring/get_link/http-response.md
+++ b/src/analytics-links/extensions/spring/get_link/http-response.md
@@ -3,7 +3,7 @@
 ``` json
 [ {
   "accessKeyId" : "myAccessKey",
-  "dataverse" : "Default",
+  "dataverse" : "travel-sample.inventory",
   "name" : "myAwsLink",
   "region" : "us-east-1",
   "secretAccessKey" : "<redacted sensitive entry>",
@@ -11,7 +11,7 @@
   "type" : "s3"
 }, {
   "accessKeyId" : "myTempAccessKey",
-  "dataverse" : "Default",
+  "dataverse" : "travel-sample.inventory",
   "name" : "myTempLink",
   "region" : "eu-west-1",
   "secretAccessKey" : "<redacted sensitive entry>",
@@ -26,7 +26,7 @@
   "clientCertificate" : null,
   "clientKey" : null,
   "clusterCompatibility" : 393221,
-  "dataverse" : "Default",
+  "dataverse" : "travel-sample.inventory",
   "encryption" : "none",
   "name" : "myCbLink",
   "nodes" : [ {

--- a/src/analytics-links/extensions/spring/post_link/http-request.md
+++ b/src/analytics-links/extensions/spring/post_link/http-request.md
@@ -1,11 +1,11 @@
-The example below creates a Couchbase link named `myCbLink` in the `Default` dataverse, with no encryption.
+The example below creates a Couchbase link named `myCbLink` in the `travel-sample.inventory` scope, with no encryption.
 
 *Curl request*
 
 ``` shell
 $ curl -v -u Administrator:password \
        -X POST http://localhost:8095/analytics/link \
-       -d dataverse=Default \
+       -d scope='`travel-sample`.inventory' \
        -d name=myCbLink \
        -d type=couchbase \
        -d hostname=remoteHostName:8091 \
@@ -14,16 +14,17 @@ $ curl -v -u Administrator:password \
        --data-urlencode password=remote.p4ssw0rd
 ```
 
-NOTE: The `username` and `password` parameters are URL-encoded to escape any special characters.
+NOTE: The `scope` value is wrapped in single quotes to escape the backticks.
+The `username` and `password` parameters are URL-encoded to escape any special characters.
 
-The example below creates an Amazon S3 link named `myAwsLink` in the `Default` dataverse.
+The example below creates an Amazon S3 link named `myAwsLink` in the `travel-sample.inventory` scope.
 
 *Curl request*
 
 ``` shell
 $ curl -v -u Administrator:password \
        -X POST http://localhost:8095/analytics/link \
-       -d dataverse=Default \
+       -d scope='`travel-sample`.inventory' \
        -d name=myAwsLink \
        -d type=s3 \
        -d region=us-east-1 \
@@ -31,16 +32,17 @@ $ curl -v -u Administrator:password \
        --data-urlencode secretAccessKey=mySecretKey
 ```
 
-NOTE: The `secretAccessKey` parameter is URL-encoded to escape any special characters.
+NOTE: The `scope` value is wrapped in single quotes to escape the backticks.
+The `secretAccessKey` parameter is URL-encoded to escape any special characters.
 
-The example below creates an Amazon S3 link named `myTempLink` with temporary credentials in the `Default` dataverse.
+The example below creates an Amazon S3 link named `myTempLink` with temporary credentials in the `travel-sample.inventory` scope.
 
 *Curl request*
 
 ``` shell
 $ curl -v -u Administrator:password \
        -X POST http://localhost:8095/analytics/link \
-       -d dataverse=Default \
+       -d scope='`travel-sample`.inventory' \
        -d name=myTempLink \
        -d type=s3 \
        -d region=eu-west-1 \
@@ -49,4 +51,5 @@ $ curl -v -u Administrator:password \
        --data-urlencode secretAccessKey=myTempSecretKey
 ```
 
-NOTE: The `secretAccessKey` parameter is URL-encoded to escape any special characters.
+NOTE: The `scope` value is wrapped in single quotes to escape the backticks.
+The `secretAccessKey` parameter is URL-encoded to escape any special characters.

--- a/src/analytics-links/extensions/spring/put_link/http-request.md
+++ b/src/analytics-links/extensions/spring/put_link/http-request.md
@@ -1,11 +1,11 @@
-The example below edits the link named `myCbLink` in the `Default` dataverse to use full encryption with a client certificate and client key.
+The example below edits the link named `myCbLink` in the `travel-sample.inventory` scope to use full encryption with a client certificate and client key.
 
 *Curl request*
 
 ``` shell
 $ curl -v -u Administrator:password \
        -X PUT http://localhost:8095/analytics/link \
-       -d dataverse=Default \
+       -d scope='`travel-sample`.inventory' \
        -d name=myCbLink \
        -d type=couchbase \
        -d hostname=remoteHostName:8091 \
@@ -15,5 +15,6 @@ $ curl -v -u Administrator:password \
        --data-urlencode "clientKey=$(cat ./cert/client.key)"
 ```
 
-NOTE: The `certificate`, `clientCertificate`, and `clientKey` parameters use command substitution with the `cat` command to return the _content_ of the referenced files.
+NOTE: The `scope` value is wrapped in single quotes to escape the backticks.
+The `certificate`, `clientCertificate`, and `clientKey` parameters use command substitution with the `cat` command to return the _content_ of the referenced files.
 The content of these files is then URL-encoded to escape any special characters.

--- a/src/analytics-links/swagger/analytics-links.yaml
+++ b/src/analytics-links/swagger/analytics-links.yaml
@@ -26,6 +26,7 @@ paths:
       summary: Create Link
       description: Creates a link.
       parameters:
+        - $ref: "#/parameters/CommonScope"
         - $ref: "#/parameters/CommonDataverse"
         - $ref: "#/parameters/CommonName"
         - $ref: "#/parameters/CommonType"
@@ -55,21 +56,40 @@ paths:
       summary: Query Links
       description: Returns information about the specified link or links.
       parameters:
+        - name: scope
+          type: string
+          in: query
+          required: false
+          description: >
+            The name of the Analytics scope containing the link.
+            Prohibited if the `dataverse` parameter is specified.
+            If both the `scope` parameter and the `dataverse` parameter are omitted, all scopes are queried for links.
+
+            
+            With this parameter, the scope name may contain one or two identifiers, separated by a dot.
+            The scope name must be given in its [display form](appendix_3_resolution.html#Resolving_database_entities); that is, if any identifier contains a special character such as a hyphen, that identifier must be wrapped in backticks (`).
         - name: dataverse
           type: string
           in: query
           required: false
           description: >
-            The name of the dataverse containing the link.
-            If this parameter is omitted, all dataverses are queried for links.
+            The name of the Analytics scope containing the link.
+            Prohibited if the `scope` parameter is specified.
+            If both the `scope` parameter and the `dataverse` parameter are omitted, all scopes are queried for links.
+
+
+            With this parameter, the scope name may only contain a single identifier.
+
+
+            Note that this parameter is deprecated, and will be removed in a future release.
         - name: name
           type: string
           in: query
           required: false
           description: >
             The name of the link.
-            If this parameter is specified, the dataverse name must be specified also.
-            If this parameter is omitted, all links will be retrieved from the specified dataverses.
+            If this parameter is specified, the scope name must be specified also.
+            If this parameter is omitted, all links will be retrieved from the specified scopes.
         - name: type
           type: string
           in: query
@@ -100,8 +120,9 @@ paths:
       summary: Edit Link
       description: >
         Edits an existing link with the provided information.
-        The link name, type, and dataverse name cannot be modified.
+        The link name, type, and scope name cannot be modified.
       parameters:
+        - $ref: "#/parameters/CommonScope"
         - $ref: "#/parameters/CommonDataverse"
         - $ref: "#/parameters/CommonName"
         - name: type
@@ -140,9 +161,10 @@ paths:
       summary: Delete Link
       description: >
         Deletes a link using the provided parameters.
-        The link cannot be deleted if any other entities, such as datasets, are using it.
+        The link cannot be deleted if any other entities are using it, such as an Analytics collection.
         The entities using the link need to be disconnected from the link, otherwise, the delete operation fails.
       parameters:
+        - $ref: "#/parameters/CommonScope"
         - $ref: "#/parameters/CommonDataverse"
         - $ref: "#/parameters/CommonName"
       security:
@@ -156,12 +178,33 @@ paths:
           $ref: '#/responses/InternalServerError'
 
 parameters:
+  CommonScope:
+    name: scope
+    type: string
+    in: formData
+    required: true
+    description: >
+      The name of the Analytics scope containing the link.
+      Required if the `dataverse` parameter is not specified; prohibited otherwise.
+
+      
+      With this parameter, the scope name may contain one or two identifiers, separated by a dot.
+      The scope name must be given in its [display form](appendix_3_resolution.html#Resolving_database_entities); that is, if any identifier contains a special character such as a hyphen, that identifier must be wrapped in backticks (`).
+
   CommonDataverse:
     name: dataverse
     type: string
     in: formData
-    required: true
-    description: The name of the dataverse containing the link.
+    required: false
+    description: >
+      The name of the Analytics scope containing the link.
+      Required if the `scope` parameter is not specified; prohibited otherwise.
+
+
+      With this parameter, the scope name may only contain a single identifier.
+
+
+      Note that this parameter is deprecated, and will be removed in a future release.
 
   CommonName:
     name: name
@@ -341,7 +384,9 @@ definitions:
     properties:
       dataverse:
         type: string
-        description: The name of the dataverse containing the link.
+        description: >
+          The name of the Analytics scope containing the link.
+          The scope name is given in its [canonical form](appendix_3_resolution.html#Resolving_database_entities).
         example: Default
       name:
         type: string

--- a/src/analytics-links/swagger/analytics-links.yaml
+++ b/src/analytics-links/swagger/analytics-links.yaml
@@ -387,7 +387,7 @@ definitions:
         description: >
           The name of the Analytics scope containing the link.
           The scope name is given in its [canonical form](appendix_3_resolution.html#Resolving_database_entities).
-        example: Default
+        example: travel-sample.inventory
       name:
         type: string
         description: The name of the link.

--- a/src/analytics-links/swagger/analytics-links.yaml
+++ b/src/analytics-links/swagger/analytics-links.yaml
@@ -67,7 +67,7 @@ paths:
 
             
             With this parameter, the scope name may contain one or two identifiers, separated by a dot.
-            The scope name must be given in its [display form](appendix_3_resolution.html#Resolving_database_entities); that is, if any identifier contains a special character such as a hyphen, that identifier must be wrapped in backticks (`).
+            The scope name must be given in its [display form](appendix_3_resolution.html#Resolving_database_entities); that is, if any identifier contains a special character such as a hyphen, that identifier must be wrapped in backticks (&grave;).
         - name: dataverse
           type: string
           in: query
@@ -189,7 +189,7 @@ parameters:
 
       
       With this parameter, the scope name may contain one or two identifiers, separated by a dot.
-      The scope name must be given in its [display form](appendix_3_resolution.html#Resolving_database_entities); that is, if any identifier contains a special character such as a hyphen, that identifier must be wrapped in backticks (`).
+      The scope name must be given in its [display form](appendix_3_resolution.html#Resolving_database_entities); that is, if any identifier contains a special character such as a hyphen, that identifier must be wrapped in backticks (&grave;).
 
   CommonDataverse:
     name: dataverse


### PR DESCRIPTION
Docs issue: [MB-42134](https://issues.couchbase.com/browse/MB-42134)

Downstream cbas-core change is at [+149609](http://review.couchbase.org/c/cbas-core/+/149609)