### PR TITLE
DOC-7808: Couchbase Transaction parameters

### DIFF
--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -437,6 +437,21 @@ __optional__|The standard deviation.|number
 [options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
+|**atrcollection** +
+__optional__|[[atrcollection-srv]]
+[.edition]#{enterprise}#
+
+Specifies the collection where xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] are stored.
+The collection must be present.
+If not specified, the active transaction record is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
+
+The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
+If any part of the path contains a special character, that part of the path must be delimited in backticks `pass:c[``]`.
+
+The {atrcollection_req}[request-level] `atrcollection` parameter specifies this property per request.
+If a request does not include this parameter, the node-level `atrcollection` setting will be used. +
+**Default** : `""` +
+**Example** : `"pass:c[default:`travel-sample`.transaction.test]"`|string
 |**auto-prepare** +
 __optional__|[[auto-prepare]]
 Specifies whether the query engine should create a prepared statement every time a N1QL request is submitted, whether the PREPARE statement is included or not.
@@ -444,6 +459,48 @@ Specifies whether the query engine should create a prepared statement every time
 Refer to xref:n1ql:n1ql-language-reference/prepare.adoc#auto-prepare[Auto-Prepare] for more information. +
 **Default** : `false` +
 **Example** : `true`|boolean
+|**cleanupclientattempts** +
+__optional__|[[cleanupclientattempts]]
+[.edition]#{enterprise}#
+
+When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
+
+The {queryCleanupClientAttempts}[cluster-level] `queryCleanupClientAttempts` setting specifies this property for the whole cluster.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
+**Default** : `true` +
+**Example** : `false`|boolean
+|**cleanuplostattempts** +
+__optional__|[[cleanuplostattempts]]
+[.edition]#{enterprise}#
+
+When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
+
+The {queryCleanupLostAttempts}[cluster-level] `queryCleanupLostAttempts` setting specifies this property for the whole cluster.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
+**Default** : `true` +
+**Example** : `false`|boolean
+|**cleanupwindow** +
+__optional__|[[cleanupwindow]]
+[.edition]#{enterprise}#
+
+Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] for cleanup.
+Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
+
+The value for this setting is a string.
+Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
+Valid units are:
+
+* `ns` (nanoseconds)
+* `us` (microseconds)
+* `ms` (milliseconds)
+* `s` (seconds)
+* `m` (minutes)
+* `h` (hours)
+
+The {queryCleanupWindow}[cluster-level] `queryCleanupWindow` setting specifies this property for the whole cluster.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
+**Default** : `"60s"` +
+**Example** : `"30s"`|string (duration)
 |**completed** +
 __optional__|[[completed]]
 A nested object that sets the parameters for the completed requests catalog.
@@ -595,7 +652,13 @@ Specifies the maximum document memory consumption for each request on this node,
 Specify `0` (the default value) to disable.
 When disabled, there is no quota.
 
-The {memory_quota_req}[request-level] `memory_quota` parameter specifies this property per request.
+Within a transaction, this setting enforces the memory quota for the transaction.
+The transaction memory quota tracks only the delta table and the transaction log (approximately).
+
+The {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies this property for the whole cluster.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+In addition, the {memory_quota_req}[request-level] `memory_quota` parameter specifies this property per request.
 If a request includes this parameter, it will be capped by the node-level `memory-quota` setting. +
 **Default** : `0` +
 **Example** : `4`|integer (int32)
@@ -624,6 +687,17 @@ This setting is provided for technical support only.
 The {queryN1qlFeatCtrl}[cluster-level] `queryN1qlFeatCtrl` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `76`|integer (int32)
+|**numatrs** +
+__optional__|[[numatrs-srv]]
+[.edition]#{enterprise}#
+
+Specifies the total number of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records].
+
+The {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies this property for the whole cluster.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+In addition, the {numatrs_req}[request-level] `numatrs` parameter specifies this property per request.
+The minimum of that and the node-level `numatrs` setting is applied.|string
 |**pipeline-batch** +
 __optional__|[[pipeline-batch-srv]]
 Controls the number of items execution operators can batch for Fetch from the KV.
@@ -646,6 +720,11 @@ In addition, the {pipeline_cap_req}[request-level] `pipeline_cap` parameter spec
 The minimum of that and the node-level `pipeline-cap` setting is applied. +
 **Default** : `512` +
 **Example** : `1024`|integer (int32)
+|**plus-servicers** +
+__optional__|[[plus-servicers]]
+The number of service threads for transactions where the scan consistency is `request_plus` or `at_plus`.
+The default is 16 times the number of logical cores. +
+**Example** : `16`|integer (int32)
 |**prepared-limit** +
 __optional__|[[prepared-limit]]
 Maximum number of prepared statements in the cache.
@@ -714,6 +793,9 @@ The number of service threads for the query. +
 __optional__|[[timeout-srv]]
 Maximum time to spend on the request before timing out (ns).
 
+The value for this setting is an integer, representing a duration in nanoseconds.
+It must not be delimited by quotes, and must not include a unit.
+
 Specify `0` (the default value) or a negative integer to disable.
 When disabled, no timeout is applied and the request runs for however long it takes.
 
@@ -721,10 +803,7 @@ The {queryTimeout}[cluster-level] `queryTimeout` setting specifies this property
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 In addition, the {timeout_req}[request-level] `timeout` parameter specifies this property per request.
-The minimum of that and the node-level `timeout` setting is applied.
-
-The node-level `timeout` setting is an integer, representing a duration in nanoseconds.
-It must not be delimited by quotes, and must not include a unit. +
+The minimum of that and the node-level `timeout` setting is applied. +
 **Default** : `0` +
 **Example** : `500000000`|integer (int64)
 |**txtimeout** +
@@ -732,25 +811,30 @@ __optional__|[[txtimeout-srv]]
 [.edition]#{enterprise}#
 
 Maximum time to spend on a transaction before timing out (ns).
+This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
+For all other requests, it is ignored.
+
+The value for this setting is an integer, representing a duration in nanoseconds.
+It must not be delimited by quotes, and must not include a unit.
 
 Specify `0` (the default value) to disable.
 When disabled, no timeout is applied and the transaction runs for however long it takes.
 
-This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
-For all other requests, it is ignored.
+The {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies this property for the whole cluster.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-The {txtimeout_req}[request-level] `txtimeout` parameter specifies this property per request.
-The minimum of that and the node-level `txtimeout` setting is applied.
-
-The node-level `txtimeout` setting is an integer, representing a duration in nanoseconds.
-It must not be delimited by quotes, and must not include a unit. +
+In addition, the {txtimeout_req}[request-level] `txtimeout` parameter specifies this property per request.
+The minimum of that and the node-level `txtimeout` setting is applied. +
 **Default** : `0` +
 **Example** : `500000000`|integer (int64)
 |**use-cbo** +
 __optional__|[[use-cbo-srv]]
 Specifies whether the cost-based optimizer is enabled.
 
-The {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
+The {queryUseCBO}[cluster-level] `queryUseCBO` setting specifies this property for the whole cluster.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+In addition, the {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
 If a request does not include this parameter, the node-level setting is used, which defaults to `true`. +
 **Default** : `true` +
 **Example** : `false`|boolean

--- a/docs/modules/rest-api/examples/query-settings-post-access.sh
+++ b/docs/modules/rest-api/examples/query-settings-post-access.sh
@@ -1,0 +1,5 @@
+curl -v -X POST -u Administrator:password \
+http://localhost:8091/settings/querySettings/curlWhitelist \
+-d '{"all_access": false,
+     "allowed_urls": ["https://company1.com"],
+     "disallowed_urls": ["https://company2.com"]}'

--- a/docs/modules/rest-api/examples/query-settings-post-access.txt
+++ b/docs/modules/rest-api/examples/query-settings-post-access.txt
@@ -1,5 +1,0 @@
-$ curl -v -X POST -u Administrator:password \
-  http://localhost:8091/settings/querySettings/curlWhitelist \
-  -d '{"all_access": false,
-       "allowed_urls": ["https://company1.com"],
-       "disallowed_urls": ["https://company2.com"]}'

--- a/docs/modules/rest-api/examples/query-settings-post-settings.jsonc
+++ b/docs/modules/rest-api/examples/query-settings-post-settings.jsonc
@@ -12,10 +12,19 @@
   "queryCompletedThreshold": 1000,
   "queryLogLevel": "info",
   "queryMaxParallelism": 1,
-  "queryN1QLFeatCtrl": 12,
+  "queryN1QLFeatCtrl": 76,
+  "queryTxTimeout": "0ms",
+  "queryMemoryQuota": 0,
+  "queryUseCBO": true,
+  "queryCleanupClientAttempts": true,
+  "queryCleanupLostAttempts": true,
+  "queryCleanupWindow": "60s",
+  "queryNumAtrs": 1024,
 // tag::access[]
   "queryCurlWhitelist": {
-    "all_access": false
+    "all_access": false,
+    "allowed_urls": [],
+    "disallowed_urls": []
   }
 }
 // end::access[]

--- a/docs/modules/rest-api/examples/query-settings-post-settings.jsonc
+++ b/docs/modules/rest-api/examples/query-settings-post-settings.jsonc
@@ -3,6 +3,9 @@
   "queryTmpSpaceDir": "/tmp",
   "queryTmpSpaceSize": 2048,
 // end::tmpSpace[]
+// tag::ellipsis[]
+// ...
+// end::ellipsis[]
   "queryPipelineBatch": 16,
   "queryPipelineCap": 512,
   "queryScanCap": 512,

--- a/docs/modules/rest-api/examples/query-settings-post-settings.sh
+++ b/docs/modules/rest-api/examples/query-settings-post-settings.sh
@@ -1,0 +1,4 @@
+curl -v -X POST -u Administrator:password \
+http://localhost:8091/settings/querySettings \
+-d 'queryTmpSpaceDir=/tmp' \
+-d 'queryTmpSpaceSize=2048'

--- a/docs/modules/rest-api/examples/query-settings-post-settings.txt
+++ b/docs/modules/rest-api/examples/query-settings-post-settings.txt
@@ -1,4 +1,0 @@
-$ curl -v -X POST -u Administrator:password \
-  http://localhost:8091/settings/querySettings \
-  -d 'queryTmpSpaceDir=/tmp' \
-  -d 'queryTmpSpaceSize=2048'

--- a/docs/modules/rest-api/partials/query-settings/definitions.adoc
+++ b/docs/modules/rest-api/partials/query-settings/definitions.adoc
@@ -58,6 +58,48 @@ endif::[]
 [options="header", cols=".^3a,.^11a,.^4a"]
 |===
 |Name|Description|Schema
+|**queryCleanupClientAttempts** +
+__optional__|[[queryCleanupClientAttempts]]
+[.edition]#{enterprise}#
+
+When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
+
+The {cleanupclientattempts}[node-level] `cleanupclientattempts` setting specifies this property for a single node.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
+**Default** : `true` +
+**Example** : `false`|boolean
+|**queryCleanupLostAttempts** +
+__optional__|[[queryCleanupLostAttempts]]
+[.edition]#{enterprise}#
+
+When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
+
+The {cleanuplostattempts}[node-level] `cleanuplostattempts` setting specifies this property for a single node.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
+**Default** : `true` +
+**Example** : `false`|boolean
+|**queryCleanupWindow** +
+__optional__|[[queryCleanupWindow]]
+[.edition]#{enterprise}#
+
+Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] for cleanup.
+Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
+
+The value for this setting is a string.
+Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
+Valid units are:
+
+* `ns` (nanoseconds)
+* `us` (microseconds)
+* `ms` (milliseconds)
+* `s` (seconds)
+* `m` (minutes)
+* `h` (hours)
+
+The {cleanupwindow}[node-level] `cleanupwindow` setting specifies this property for a single node.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
+**Default** : `"60s"` +
+**Example** : `"30s"`|string (duration)
 |**queryCompletedLimit** +
 __optional__|[[queryCompletedLimit]]
 Sets the number of requests to be logged in the completed requests catalog.
@@ -126,7 +168,7 @@ Similarly, if the value is greater than the number of allowed cores, the maximum
 In Community Edition, the number of allowed cores cannot be greater than 4.
 In Enterprise Edition, there is no limit to the number of allowed cores.)
 
-The {max-parallelism-srv}[node-level] `max_parallelism` setting specifies this property for a single node.
+The {max-parallelism-srv}[node-level] `max-parallelism` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 In addition, there is a {max_parallelism_req}[request-level] `max_parallelism` parameter.
@@ -138,6 +180,20 @@ To enable queries to run in parallel, you must specify the cluster-level `queryM
 Refer to xref:n1ql:n1ql-language-reference/index-partitioning.adoc#max-parallelism[Max Parallelism] for more information. +
 **Default** : `1` +
 **Example** : `0`|integer (int32)
+|**queryMemoryQuota** +
+__optional__|[[queryMemoryQuota]]
+Specifies the maximum document memory consumption for queries on all Query nodes in the cluster, in MB.
+
+Within a transaction, this setting enforces the memory quota for the transaction.
+The transaction memory quota tracks only the delta table and the transaction log (approximately).
+
+The {memory-quota-srv}[node-level] `memory-quota` setting specifies this property for a single node.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+In addition, there is a {memory_quota_req}[request-level] `memory_quota` parameter.
+If a request includes this parameter, it will be capped by the node-level `memory-quota` setting. +
+**Default** : `0` +
+**Example** : `4`|integer (int32)
 |**queryN1qlFeatCtrl** +
 __optional__|[[queryN1qlFeatCtrl]]
 N1QL feature control.
@@ -145,6 +201,20 @@ This setting is provided for technical support only.
 
 The {n1ql-feat-ctrl}[node-level] `n1ql-feat-ctrl` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.|integer (int32)
+|**queryNumAtrs** +
+__optional__|[[queryNumAtrs]]
+[.edition]#{enterprise}#
+
+Specifies the total number of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] for all Query nodes in the cluster.
+
+The {numatrs-srv}[node-level] `numatrs` setting specifies this property for a single node.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+In addition, there is a {numatrs_req}[request-level] `numatrs` parameter.
+If a request includes this parameter, it will be capped by the node-level `numatrs` setting. +
+**Default** : `1024` +
+**Minimum value (exclusive)** : `0` +
+**Example** : `512`|integer (int32)
 |**queryPipelineBatch** +
 __optional__|[[queryPipelineBatch]]
 Controls the number of items execution operators can batch for Fetch from the KV.
@@ -195,6 +265,9 @@ The minimum of that and the node-level `scan-cap` setting is applied. +
 __optional__|[[queryTimeout]]
 Maximum time to spend on the request before timing out (ns).
 
+The value for this setting is an integer, representing a duration in nanoseconds.
+It must not be delimited by quotes, and must not include a unit.
+
 Specify `0` (the default value) or a negative integer to disable.
 When disabled, no timeout is applied and the request runs for however long it takes.
 
@@ -202,12 +275,38 @@ The {timeout-srv}[node-level] `timeout` setting specifies this property for a si
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 In addition, the {timeout_req}[request-level] `timeout` parameter specifies this property per request.
-The minimum of that and the node-level `timeout` setting is applied.
-
-The cluster-level `queryTimeout` setting is an integer, representing a duration in nanoseconds.
-It must not be delimited by quotes, and must not include a unit. +
+The minimum of that and the node-level `timeout` setting is applied. +
 **Default** : `0` +
 **Example** : `500000000`|integer (int64)
+|**queryTxTimeout** +
+__optional__|[[queryTxTimeout]]
+[.edition]#{enterprise}#
+
+Maximum time to spend on a transaction before timing out.
+This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
+For all other requests, it is ignored.
+
+The value for this setting is a string.
+Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
+Valid units are:
+
+* `ns` (nanoseconds)
+* `us` (microseconds)
+* `ms` (milliseconds)
+* `s` (seconds)
+* `m` (minutes)
+* `h` (hours)
+
+Specify `0ms` (the default value) to disable.
+When disabled, no timeout is applied and the transaction runs for however long it takes.
+
+The {txtimeout-srv}[node-level] `txtimeout` setting specifies this property for a single node.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+In addition, there is a {txtimeout_req}[request-level] `txtimeout` parameter.
+If a request includes this parameter, it will be capped by the node-level `txtimeout` setting. +
+**Default** : `"0ms"` +
+**Example** : `"0.5s"`|string (duration)
 |**queryTmpSpaceDir** +
 __optional__|[[queryTmpSpaceDir]]
 The path to which the indexer writes temporary backfill files, to store any transient data during query processing.
@@ -227,6 +326,17 @@ Setting the size to `-1` means the size is unlimited.
 The maximum size is limited only by the available disk space. +
 **Default** : `5120` +
 **Example** : `2048`|integer (int32)
+|**queryUseCBO** +
+__optional__|[[queryUseCBO]]
+Specifies whether the cost-based optimizer is enabled.
+
+The {use-cbo-srv}[node-level] `use-cbo` setting specifies this property for a single node.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+In addition, the {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
+If a request does not include this parameter, the node-level setting is used, which defaults to `true`. +
+**Default** : `true` +
+**Example** : `false`|boolean
 |**queryCurlWhitelist** +
 __optional__|[[queryCurlWhitelist]]
 An object which determines which URLs may be accessed by the `CURL()` function.|<<_access,Access>>

--- a/docs/modules/rest-api/partials/query-settings/paths.adoc
+++ b/docs/modules/rest-api/partials/query-settings/paths.adoc
@@ -51,8 +51,8 @@ The example below gets the current cluster-level query settings.
 .Curl request
 [source,shell]
 ----
-$ curl -v -u Administrator:password \
-  http://localhost:8091/settings/querySettings
+curl -v -u Administrator:password \
+http://localhost:8091/settings/querySettings
 ----
 ====
 
@@ -76,9 +76,18 @@ $ curl -v -u Administrator:password \
   "queryCompletedThreshold": 1000,
   "queryLogLevel": "info",
   "queryMaxParallelism": 1,
-  "queryN1QLFeatCtrl": 12,
+  "queryN1QLFeatCtrl": 76,
+  "queryTxTimeout": "0ms",
+  "queryMemoryQuota": 0,
+  "queryUseCBO": true,
+  "queryCleanupClientAttempts": true,
+  "queryCleanupLostAttempts": true,
+  "queryCleanupWindow": "60s",
+  "queryNumAtrs": 1024,
   "queryCurlWhitelist": {
-    "all_access": false
+    "all_access": false,
+    "allowed_urls": [],
+    "disallowed_urls": []
   }
 }
 ----
@@ -133,7 +142,7 @@ The example below changes the temp file directory to `/tmp` and the temp file si
 .Curl request
 [source,shell]
 ----
-include::rest-api:example$query-settings-post-settings.txt[]
+include::rest-api:example$query-settings-post-settings.sh[]
 ----
 ====
 
@@ -145,7 +154,7 @@ include::rest-api:example$query-settings-post-settings.txt[]
 .Response 200
 [source,json]
 ----
-include::rest-api:example$query-settings-post-settings.jsonc[tags=**]
+include::rest-api:example$query-settings-post-settings.jsonc[tags=!ellipsis]
 ----
 ====
 
@@ -187,8 +196,8 @@ The example below gets the current cluster-level CURL access settings.
 .Curl request
 [source,shell]
 ----
-$ curl -v -u Administrator:password \
-  http://localhost:8091/settings/querySettings/curlWhitelist
+curl -v -u Administrator:password \
+http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====
 
@@ -200,7 +209,11 @@ $ curl -v -u Administrator:password \
 .Response 200
 [source,json]
 ----
-{"all_access":false}
+{
+  "all_access": false,
+  "allowed_urls": [],
+  "disallowed_urls": []
+}
 ----
 ====
 
@@ -253,7 +266,7 @@ The example below specifies that `+++https://company1.com+++` is allowed, and `+
 .Curl request
 [source,shell]
 ----
-include::rest-api:example$query-settings-post-access.txt[]
+include::rest-api:example$query-settings-post-access.sh[]
 ----
 ====
 

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1472,9 +1472,11 @@ definitions:
       plus-servicers:
         type: integer
         format: int32
-        default: 16
-        # description: |
-        #   FIXME: [[plus-servicers]]
+        example: 16
+        description: |
+          [[plus-servicers]]
+          The number of service threads for transactions where the scan consistency is `request_plus` or `at_plus`.
+          The default is 16 times the number of logical cores.
       prepared-limit:
         type: integer
         format: int32

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1391,6 +1391,9 @@ definitions:
           Specify `0` (the default value) to disable.
           When disabled, there is no quota.
 
+          Within a transaction, this setting enforces the memory quota for the transaction.
+          The transaction memory quota tracks only the delta table and the transaction log (approximately).
+
           The {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1076,6 +1076,23 @@ definitions:
     type: object
     title: Settings
     properties:
+      atrcollection:
+        type: string
+        default: ""
+        example: default:`travel-sample`.transaction.test
+        description: |
+          [[atrcollection-srv]]
+          [.edition]#{enterprise}#
+
+          Specifies the collection where xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] are stored.
+          The collection must be present.
+          If not specified, the active transaction record is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
+
+          The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
+          If any part of the path contains a special character, that part of the path must be delimited in backticks `pass:c[``]`.
+
+          The {atrcollection_req}[request-level] `atrcollection` parameter specifies this property per request.
+          If a request does not include this parameter, the node-level `atrcollection` setting will be used.
       auto-prepare:
         type: boolean
         default: false
@@ -1085,6 +1102,56 @@ definitions:
           Specifies whether the query engine should create a prepared statement every time a N1QL request is submitted, whether the PREPARE statement is included or not.
           
           Refer to xref:n1ql:n1ql-language-reference/prepare.adoc#auto-prepare[Auto-Prepare] for more information.
+
+      cleanupclientattempts:
+        type: boolean
+        default: true
+        example: false
+        description: |
+          [[cleanupclientattempts]]
+          [.edition]#{enterprise}#
+
+          When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
+
+          The {queryCleanupClientAttempts}[cluster-level] `queryCleanupClientAttempts` setting specifies this property for the whole cluster.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+      cleanuplostattempts:
+        type: boolean
+        default: true
+        example: false
+        description: |
+          [[cleanuplostattempts]]
+          [.edition]#{enterprise}#
+
+          When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
+
+          The {queryCleanupLostAttempts}[cluster-level] `queryCleanupLostAttempts` setting specifies this property for the whole cluster.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+      cleanupwindow:
+        type: string
+        format: duration
+        default: 60s
+        example: 30s
+        description: |
+          [[cleanupwindow]]
+          [.edition]#{enterprise}#
+
+          Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] for cleanup.
+          Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
+
+          The value for this setting is a string.
+          Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
+          Valid units are:
+
+          * `ns` (nanoseconds)
+          * `us` (microseconds)
+          * `ms` (milliseconds)
+          * `s` (seconds)
+          * `m` (minutes)
+          * `h` (hours)
+
+          The {queryCleanupWindow}[cluster-level] `queryCleanupWindow` setting specifies this property for the whole cluster.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
       completed:
         type: object
         title: Logging parameters
@@ -1347,6 +1414,19 @@ definitions:
           [[mutexprofile]]
           Mutex profile.
           This setting is provided for technical support only.
+      numatrs:
+        type: string
+        description: |
+          [[numatrs-srv]]
+          [.edition]#{enterprise}#
+
+          Specifies the total number of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records].
+
+          The {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies this property for the whole cluster.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          In addition, the {numatrs_req}[request-level] `numatrs` parameter specifies this property per request.
+          The minimum of that and the node-level `numatrs` setting is applied.
       n1ql-feat-ctrl:
         type: integer
         format: int32
@@ -1386,6 +1466,12 @@ definitions:
 
           In addition, the {pipeline_cap_req}[request-level] `pipeline_cap` parameter specifies this property per request.
           The minimum of that and the node-level `pipeline-cap` setting is applied.
+      plus-servicers:
+        type: integer
+        format: int32
+        default: 16
+        # description: |
+        #   FIXME: [[plus-servicers]]
       prepared-limit:
         type: integer
         format: int32

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1391,7 +1391,10 @@ definitions:
           Specify `0` (the default value) to disable.
           When disabled, there is no quota.
 
-          The {memory_quota_req}[request-level] `memory_quota` parameter specifies this property per request.
+          The {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies this property for the whole cluster.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          In addition, the {memory_quota_req}[request-level] `memory_quota` parameter specifies this property per request.
           If a request includes this parameter, it will be capped by the node-level `memory-quota` setting.
       memprofile:
         type: string
@@ -1565,14 +1568,14 @@ definitions:
           Specify `0` (the default value) or a negative integer to disable.
           When disabled, no timeout is applied and the request runs for however long it takes.
 
+          This setting is an integer, representing a duration in nanoseconds.
+          It must not be delimited by quotes, and must not include a unit.
+
           The {queryTimeout}[cluster-level] `queryTimeout` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
           In addition, the {timeout_req}[request-level] `timeout` parameter specifies this property per request.
           The minimum of that and the node-level `timeout` setting is applied.
-
-          The node-level `timeout` setting is an integer, representing a duration in nanoseconds.
-          It must not be delimited by quotes, and must not include a unit.
       txtimeout:
         type: integer
         format: int64
@@ -1590,11 +1593,14 @@ definitions:
           This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
           For all other requests, it is ignored.
 
-          The {txtimeout_req}[request-level] `txtimeout` parameter specifies this property per request.
-          The minimum of that and the node-level `txtimeout` setting is applied.
-
-          The node-level `txtimeout` setting is an integer, representing a duration in nanoseconds.
+          This setting is an integer, representing a duration in nanoseconds.
           It must not be delimited by quotes, and must not include a unit.
+
+          The {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies this property for the whole cluster.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          In addition, the {txtimeout_req}[request-level] `txtimeout` parameter specifies this property per request.
+          The minimum of that and the node-level `txtimeout` setting is applied.
       use-cbo:
         type: boolean
         default: true
@@ -1603,7 +1609,10 @@ definitions:
           [[use-cbo-srv]]
           Specifies whether the cost-based optimizer is enabled.
 
-          The {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
+          The {queryUseCBO}[cluster-level] `queryUseCBO` setting specifies this property for the whole cluster.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          In addition, the {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
           If a request does not include this parameter, the node-level setting is used, which defaults to `true`.
 
 parameters:

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1565,11 +1565,11 @@ definitions:
           [[timeout-srv]]
           Maximum time to spend on the request before timing out (ns).
 
+          The value for this setting is an integer, representing a duration in nanoseconds.
+          It must not be delimited by quotes, and must not include a unit.
+
           Specify `0` (the default value) or a negative integer to disable.
           When disabled, no timeout is applied and the request runs for however long it takes.
-
-          This setting is an integer, representing a duration in nanoseconds.
-          It must not be delimited by quotes, and must not include a unit.
 
           The {queryTimeout}[cluster-level] `queryTimeout` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
@@ -1586,15 +1586,14 @@ definitions:
           [.edition]#{enterprise}#
 
           Maximum time to spend on a transaction before timing out (ns).
-
-          Specify `0` (the default value) to disable.
-          When disabled, no timeout is applied and the transaction runs for however long it takes.
-
           This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
           For all other requests, it is ignored.
 
-          This setting is an integer, representing a duration in nanoseconds.
+          The value for this setting is an integer, representing a duration in nanoseconds.
           It must not be delimited by quotes, and must not include a unit.
+
+          Specify `0` (the default value) to disable.
+          When disabled, no timeout is applied and the transaction runs for however long it takes.
 
           The {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1079,7 +1079,7 @@ definitions:
       atrcollection:
         type: string
         default: ""
-        example: default:`travel-sample`.transaction.test
+        example: pass:c[default:`travel-sample`.transaction.test]
         description: |
           [[atrcollection-srv]]
           [.edition]#{enterprise}#

--- a/src/query-settings/extensions/spring/get_access/http-request.adoc
+++ b/src/query-settings/extensions/spring/get_access/http-request.adoc
@@ -4,7 +4,7 @@ The example below gets the current cluster-level CURL access settings.
 .Curl request
 [source,shell]
 ----
-$ curl -v -u Administrator:password \
-  http://localhost:8091/settings/querySettings/curlWhitelist
+curl -v -u Administrator:password \
+http://localhost:8091/settings/querySettings/curlWhitelist
 ----
 ====

--- a/src/query-settings/extensions/spring/get_access/http-response.adoc
+++ b/src/query-settings/extensions/spring/get_access/http-response.adoc
@@ -3,6 +3,10 @@
 .Response 200
 [source,json]
 ----
-{"all_access":false}
+{
+  "all_access": false,
+  "allowed_urls": [],
+  "disallowed_urls": []
+}
 ----
 ====

--- a/src/query-settings/extensions/spring/get_settings/http-request.adoc
+++ b/src/query-settings/extensions/spring/get_settings/http-request.adoc
@@ -4,7 +4,7 @@ The example below gets the current cluster-level query settings.
 .Curl request
 [source,shell]
 ----
-$ curl -v -u Administrator:password \
-  http://localhost:8091/settings/querySettings
+curl -v -u Administrator:password \
+http://localhost:8091/settings/querySettings
 ----
 ====

--- a/src/query-settings/extensions/spring/get_settings/http-response.adoc
+++ b/src/query-settings/extensions/spring/get_settings/http-response.adoc
@@ -15,9 +15,18 @@
   "queryCompletedThreshold": 1000,
   "queryLogLevel": "info",
   "queryMaxParallelism": 1,
-  "queryN1QLFeatCtrl": 12,
+  "queryN1QLFeatCtrl": 76,
+  "queryTxTimeout": "0ms",
+  "queryMemoryQuota": 0,
+  "queryUseCBO": true,
+  "queryCleanupClientAttempts": true,
+  "queryCleanupLostAttempts": true,
+  "queryCleanupWindow": "60s",
+  "queryNumAtrs": 1024,
   "queryCurlWhitelist": {
-    "all_access": false
+    "all_access": false,
+    "allowed_urls": [],
+    "disallowed_urls": []
   }
 }
 ----

--- a/src/query-settings/extensions/spring/post_access/http-request.adoc
+++ b/src/query-settings/extensions/spring/post_access/http-request.adoc
@@ -4,6 +4,6 @@ The example below specifies that `+++https://company1.com+++` is allowed, and `+
 .Curl request
 [source,shell]
 ----
-include::rest-api:example$query-settings-post-access.txt[]
+include::rest-api:example$query-settings-post-access.sh[]
 ----
 ====

--- a/src/query-settings/extensions/spring/post_settings/http-request.adoc
+++ b/src/query-settings/extensions/spring/post_settings/http-request.adoc
@@ -4,6 +4,6 @@ The example below changes the temp file directory to `/tmp` and the temp file si
 .Curl request
 [source,shell]
 ----
-include::rest-api:example$query-settings-post-settings.txt[]
+include::rest-api:example$query-settings-post-settings.sh[]
 ----
 ====

--- a/src/query-settings/extensions/spring/post_settings/http-response.adoc
+++ b/src/query-settings/extensions/spring/post_settings/http-response.adoc
@@ -3,6 +3,6 @@
 .Response 200
 [source,json]
 ----
-include::rest-api:example$query-settings-post-settings.jsonc[tags=**]
+include::rest-api:example$query-settings-post-settings.jsonc[tags=!ellipsis]
 ----
 ====

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -95,6 +95,55 @@ definitions:
     type: object
     title: Settings
     properties:
+      queryCleanupClientAttempts:
+        type: boolean
+        default: true
+        example: false
+        description: |
+          [[queryCleanupClientAttempts]]
+          [.edition]#{enterprise}#
+
+          When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
+
+          The {cleanupclientattempts}[node-level] `cleanupclientattempts` setting specifies this property for a single node.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+      queryCleanupLostAttempts:
+        type: boolean
+        default: true
+        example: false
+        description: |
+          [[queryCleanupLostAttempts]]
+          [.edition]#{enterprise}#
+
+          When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
+
+          The {cleanuplostattempts}[node-level] `cleanuplostattempts` setting specifies this property for a single node.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+      queryCleanupWindow:
+        type: string
+        format: duration
+        default: 60s
+        example: 30s
+        description: |
+          [[queryCleanupWindow]]
+          [.edition]#{enterprise}#
+
+          Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] for cleanup.
+          Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
+
+          The value for this setting is a string.
+          Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
+          Valid units are:
+
+          * `ns` (nanoseconds)
+          * `us` (microseconds)
+          * `ms` (milliseconds)
+          * `s` (seconds)
+          * `m` (minutes)
+          * `h` (hours)
+
+          The {cleanupwindow}[node-level] `cleanupwindow` setting specifies this property for a single node.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
       queryCompletedLimit:
         type: integer
         format: int32

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -177,7 +177,7 @@ definitions:
           In Community Edition, the number of allowed cores cannot be greater than 4.
           In Enterprise Edition, there is no limit to the number of allowed cores.)
 
-          The {max-parallelism-srv}[node-level] `max_parallelism` setting specifies this property for a single node.
+          The {max-parallelism-srv}[node-level] `max-parallelism` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
           In addition, there is a {max_parallelism_req}[request-level] `max_parallelism` parameter.
@@ -187,6 +187,20 @@ definitions:
           To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
 
           Refer to xref:n1ql:n1ql-language-reference/index-partitioning.adoc#max-parallelism[Max Parallelism] for more information.
+      queryMemoryQuota:
+        type: integer
+        format: int32
+        default: 0
+        example: 4
+        description: |
+          [[queryMemoryQuota]]
+          Specifies the maximum document memory consumption for queries on all Query nodes in the cluster, in MB.
+
+          The {memory-quota-srv}[node-level] `memory-quota` setting specifies this property for a single node.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          In addition, there is a {memory_quota_req}[request-level] `memory_quota` parameter.
+          If a request includes this parameter, it will be capped by the node-level `memory-quota` setting.
       queryN1qlFeatCtrl:
         type: integer
         format: int32
@@ -197,6 +211,24 @@ definitions:
 
           The {n1ql-feat-ctrl}[node-level] `n1ql-feat-ctrl` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+      queryNumAtrs:
+        type: integer
+        format: int32
+        minimum: 0
+        exclusiveMinimum: true
+        default: 1024
+        example: 512
+        description: |
+          [[queryNumAtrs]]
+          [.edition]#{enterprise}#
+
+          Specifies the total number of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] for all Query nodes in the cluster.
+
+          The {numatrs-srv}[node-level] `numatrs` setting specifies this property for a single node.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          In addition, there is a {numatrs_req}[request-level] `numatrs` parameter.
+          If a request includes this parameter, it will be capped by the node-level `numatrs` setting.
       queryPipelineBatch:
         type: integer
         format: int32
@@ -275,6 +307,39 @@ definitions:
 
           The cluster-level `queryTimeout` setting is an integer, representing a duration in nanoseconds.
           It must not be delimited by quotes, and must not include a unit.
+      queryTxTimeout:
+        type: string
+        format: duration
+        default: "0ms"
+        example: "0.5s"
+        description: |
+          [[queryTxTimeout]]
+          [.edition]#{enterprise}#
+
+          Maximum time to spend on a transaction before timing out.
+
+          Specify `0ms` (the default value) to disable.
+          When disabled, no timeout is applied and the transaction runs for however long it takes.
+
+          This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
+          For all other requests, it is ignored.
+
+          The value for this setting is a string.
+          Its format includes an amount and a mandatory unit, e.g. `10ms` (10 milliseconds) or `0.5s` (half a second).
+          Valid units are:
+
+          * `ns` (nanoseconds)
+          * `us` (microseconds)
+          * `ms` (milliseconds)
+          * `s` (seconds)
+          * `m` (minutes)
+          * `h` (hours)
+
+          The {txtimeout-srv}[node-level] `txtimeout` setting specifies this property for a single node.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          In addition, there is a {txtimeout_req}[request-level] `txtimeout` parameter.
+          If a request includes this parameter, it will be capped by the node-level `txtimeout` setting.
       queryTmpSpaceDir:
         type: string
         example: "/opt/couchbase/var/lib/couchbase/tmp"
@@ -299,6 +364,19 @@ definitions:
           Setting the size to `-1` means the size is unlimited.
 
           The maximum size is limited only by the available disk space.
+      queryUseCBO:
+        type: boolean
+        default: true
+        example: false
+        description: |
+          [[queryUseCBO]]
+          Specifies whether the cost-based optimizer is enabled.
+
+          The {use-cbo-srv}[node-level] `use-cbo` setting specifies this property for a single node.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          In addition, the {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
+          If a request does not include this parameter, the node-level setting is used, which defaults to `true`.
       queryCurlWhitelist:
         description: |
           [[queryCurlWhitelist]]

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -345,6 +345,9 @@ definitions:
           [[queryTimeout]]
           Maximum time to spend on the request before timing out (ns).
 
+          The value for this setting is an integer, representing a duration in nanoseconds.
+          It must not be delimited by quotes, and must not include a unit.
+
           Specify `0` (the default value) or a negative integer to disable.
           When disabled, no timeout is applied and the request runs for however long it takes.
 
@@ -353,9 +356,6 @@ definitions:
 
           In addition, the {timeout_req}[request-level] `timeout` parameter specifies this property per request.
           The minimum of that and the node-level `timeout` setting is applied.
-
-          The cluster-level `queryTimeout` setting is an integer, representing a duration in nanoseconds.
-          It must not be delimited by quotes, and must not include a unit.
       queryTxTimeout:
         type: string
         format: duration
@@ -366,10 +366,6 @@ definitions:
           [.edition]#{enterprise}#
 
           Maximum time to spend on a transaction before timing out.
-
-          Specify `0ms` (the default value) to disable.
-          When disabled, no timeout is applied and the transaction runs for however long it takes.
-
           This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
           For all other requests, it is ignored.
 
@@ -383,6 +379,9 @@ definitions:
           * `s` (seconds)
           * `m` (minutes)
           * `h` (hours)
+
+          Specify `0ms` (the default value) to disable.
+          When disabled, no timeout is applied and the transaction runs for however long it takes.
 
           The {txtimeout-srv}[node-level] `txtimeout` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -245,6 +245,9 @@ definitions:
           [[queryMemoryQuota]]
           Specifies the maximum document memory consumption for queries on all Query nodes in the cluster, in MB.
 
+          Within a transaction, this setting enforces the memory quota for the transaction.
+          The transaction memory quota tracks only the delta table and the transaction log (approximately).
+
           The {memory-quota-srv}[node-level] `memory-quota` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 


### PR DESCRIPTION
Source OpenAPI files and examples for cluster-level and node-level transaction parameters.

Downstream documentation pull request: [docs-server#1909](https://github.com/couchbase/docs-server/pull/1909)