### PR TITLE
DOC-8387: Primary index doesn't include transactional documents

### DIFF
--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1084,7 +1084,7 @@ definitions:
           [[atrcollection-srv]]
           [.edition]#{enterprise}#
 
-          Specifies the collection where xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] are stored.
+          Specifies the collection where xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] are stored.
           The collection must be present.
           If not specified, the active transaction record is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
 
@@ -1136,7 +1136,7 @@ definitions:
           [[cleanupwindow]]
           [.edition]#{enterprise}#
 
-          Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] for cleanup.
+          Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for cleanup.
           Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
 
           The value for this setting is a string.
@@ -1426,7 +1426,7 @@ definitions:
           [[numatrs-srv]]
           [.edition]#{enterprise}#
 
-          Specifies the total number of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records].
+          Specifies the total number of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records].
 
           The {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -128,7 +128,7 @@ definitions:
           [[queryCleanupWindow]]
           [.edition]#{enterprise}#
 
-          Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] for cleanup.
+          Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for cleanup.
           Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
 
           The value for this setting is a string.
@@ -274,7 +274,7 @@ definitions:
           [[queryNumAtrs]]
           [.edition]#{enterprise}#
 
-          Specifies the total number of xref:learn:data/transactions.adoc#understanding-transactions[active transaction records] for all Query nodes in the cluster.
+          Specifies the total number of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for all Query nodes in the cluster.
 
           The {numatrs-srv}[node-level] `numatrs` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.


### PR DESCRIPTION
Minor edits: changing links to active transaction record.

Docs issue: [DOC-8378](https://issues.couchbase.com/browse/DOC-8378)