### PR TITLE
DOC-9297: Document redaction of index names

### DIFF
--- a/docs/modules/rest-api/partials/index-stats/overview.adoc
+++ b/docs/modules/rest-api/partials/index-stats/overview.adoc
@@ -23,7 +23,7 @@ where [.var]`node` is the host name or IP address of a computer running the inde
 
 === Version information
 [%hardbreaks]
-__Version__ : 7.0
+__Version__ : 7.1
 
 
 === Produces

--- a/docs/modules/rest-api/partials/index-stats/paths.adoc
+++ b/docs/modules/rest-api/partials/index-stats/paths.adoc
@@ -24,6 +24,9 @@ GET /api/v1/stats
 Returns statistics for an index node, and for all indexes on that node.
 
 
+[[_get_node_stats_parameters]]
+
+
 ==== Parameters
 
 [options="header", cols=".^2a,.^3a,.^9a,.^4a,.^2a"]
@@ -31,6 +34,8 @@ Returns statistics for an index node, and for all indexes on that node.
 |Type|Name|Description|Schema|Default
 |**Query**|**pretty** +
 __optional__|Whether the output should be formatted with indentations and newlines.|boolean|`"false"`
+|**Query**|**redact** +
+__optional__|Whether keyspace and index names should be redacted in the output.|boolean|`"false"`
 |**Query**|**skipEmpty** +
 __optional__|Whether empty, null, or zero statistics should be omitted from the output.|boolean|`"false"`
 |===
@@ -57,7 +62,9 @@ __required__|A nested object containing statistics for the current index node.|<
 __optional__|A nested object containing statistics for an entire index.
 
 * `__keyspace__` is the bucket, scope, and collection containing the index.
-* `__index__` is the name of the index.|<<_index,Index>>
+* `__index__` is the name of the index.
+
+If the <<_get_node_stats_parameters,redact>> query parameter was set to `true`, the keyspace and index names are replaced by the index instance ID for confidentiality.|<<_index,Index>>
 |===
 
 
@@ -78,7 +85,7 @@ __optional__|A nested object containing statistics for an entire index.
 Request {counter:example}: Return statistics for an index node and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
 "http://localhost:9102/api/v1/stats?pretty=true"
@@ -90,10 +97,22 @@ curl -X GET -u Administrator:password \
 Request {counter:example}: Return statistics for an index node, omit empty results, and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
 "http://localhost:9102/api/v1/stats?skipEmpty=true&pretty=true"
+----
+====
+
+[[node-example-3,request {counter:xref}]]
+====
+Request {counter:example}: Return statistics for an index node, omit empty results, redact index names, and format the output.
+
+.Curl request
+[source,sh]
+----
+curl -X GET -u Administrator:password \
+"http://localhost:9102/api/v1/stats?skipEmpty=true&redact=true&pretty=true"
 ----
 ====
 
@@ -172,7 +191,7 @@ Result of <<node-example-1>>.
       "scan_bytes_read": 0,
       "total_scan_duration": 0
    },
-   ...
+   // ...
    }
 }
 ----
@@ -189,7 +208,8 @@ Result of <<node-example-2>>.
       "indexer_state": "Active",
       "memory_quota": 536870912,
       "memory_total_storage": 14708736,
-      "memory_used": 376973312
+      "memory_used": 376973312,
+      "total_indexer_gc_pause_ns": 72809334
    },
    "travel-sample:def_airportname": {
       "avg_item_size": 73,
@@ -211,7 +231,46 @@ Result of <<node-example-2>>.
       "memory_used": 16330,
       "recs_on_disk": 7380
    },
-   ...
+   // ...
+}
+----
+====
+
+====
+Result of <<node-example-3>>.
+
+.Response 200
+[source,json]
+----
+{
+   "10862128657611330848": {
+      "avg_item_size": 73,
+      "data_size": 514623,
+      "disk_size": 872448,
+      "frag_percent": 56,
+      "initial_build_progress": 100,
+      "items_count": 1968,
+      "memory_used": 3498,
+      "recs_on_disk": 1968
+   },
+   "1358505159407317360": {
+      "avg_item_size": 59,
+      "data_size": 1083447,
+      "disk_size": 1138688,
+      "frag_percent": 56,
+      "initial_build_progress": 100,
+      "items_count": 7380,
+      "memory_used": 16330,
+      "recs_on_disk": 7380
+   },
+   // ...
+   "indexer": {
+      "indexer_state": "Active",
+      "memory_quota": 536870912,
+      "memory_total_storage": 14708736,
+      "memory_used": 376973312,
+      "total_indexer_gc_pause_ns": 72809334
+   }
 }
 ----
 ====
@@ -246,6 +305,8 @@ If any part of the keyspace name contains a dot, that part of the keyspace name 
 For example, `pass:c[`bucket.1`.scope.collection]`.|string|
 |**Query**|**pretty** +
 __optional__|Whether the output should be formatted with indentations and newlines.|boolean|`"false"`
+|**Query**|**redact** +
+__optional__|Whether keyspace and index names should be redacted in the output.|boolean|`"false"`
 |**Query**|**skipEmpty** +
 __optional__|Whether empty, null, or zero statistics should be omitted from the output.|boolean|`"false"`
 |===
@@ -285,7 +346,9 @@ The keyspace name may be incorrect, the keyspace may contain no indexes, the ind
 __required__|A nested object containing statistics for an entire index.
 
 * `__keyspace__` is the bucket, scope, and collection containing the index.
-* `__index__` is the name of the index.|<<_index,Index>>
+* `__index__` is the name of the index.
+
+If the <<_get_keyspace_stats_parameters,redact>> query parameter was set to `true`, the keyspace and index names are replaced by the index instance ID for confidentiality.|<<_index,Index>>
 |===
 
 
@@ -305,7 +368,7 @@ __required__|A nested object containing statistics for an entire index.
 Request {counter:example}: Return statistics for all indexes in a scope, omit empty results, and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
 "http://localhost:9102/api/v1/stats/travel-sample.inventory?pretty=true&skipEmpty=true"
@@ -317,7 +380,7 @@ curl -X GET -u Administrator:password \
 Request {counter:example}: Return statistics for all indexes in a collection, omit empty results, and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
 "http://localhost:9102/api/v1/stats/travel-sample.inventory.airline?pretty=true&skipEmpty=true"
@@ -364,7 +427,7 @@ Result of <<keyspace-example-1>>.
       "memory_used": 3880,
       "recs_on_disk": 1968
    },
-   ...
+   // ...
 }
 ----
 ====
@@ -434,6 +497,8 @@ __required__|The name of an index.|string|
 __optional__|Whether the output should be formatted with indentations and newlines.|boolean|`"false"`
 |**Query**|**partition** +
 __optional__|Whether statistics for index partitions should be included.|boolean|`"false"`
+|**Query**|**redact** +
+__optional__|Whether keyspace and index names should be redacted in the output.|boolean|`"false"`
 |**Query**|**skipEmpty** +
 __optional__|Whether empty, null, or zero statistics should be omitted from the output.|boolean|`"false"`
 |===
@@ -479,7 +544,9 @@ The keyspace name may be incorrect, the keyspace may contain no indexes, the ind
 __required__|A nested object containing statistics for an entire index.
 
 * `__keyspace__` is the bucket, scope, and collection containing the index.
-* `__index__` is the name of the index.|<<_index,Index>>
+* `__index__` is the name of the index.
+
+If the <<_get_index_stats_parameters,redact>> query parameter was set to `true`, the keyspace and index names are replaced by the index instance ID for confidentiality.|<<_index,Index>>
 |**Partition-__num__** +
 __optional__|A nested object containing statistics.
 
@@ -504,10 +571,10 @@ __optional__|A nested object containing statistics.
 Request {counter:example}: Return statistics for an index and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
-"http://localhost:9102/api/v1/stats/travel-sample.inventory.route/def_sourceairport_partn?pretty=true"
+"http://localhost:9102/api/v1/stats/travel-sample.inventory.route/idx_partn?pretty=true"
 ----
 ====
 
@@ -516,10 +583,10 @@ curl -X GET -u Administrator:password \
 Request {counter:example}: Return statistics for an index, include partitions, and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
-"http://localhost:9102/api/v1/stats/travel-sample.inventory.route/def_sourceairport_partn?partition=true&pretty=true"
+"http://localhost:9102/api/v1/stats/travel-sample.inventory.route/idx_partn?partition=true&pretty=true"
 ----
 ====
 
@@ -533,7 +600,7 @@ Result of <<index-example-1>>.
 [source,json]
 ----
 {
-   "travel-sample:inventory:route:def_sourceairport_partn": {
+   "travel-sample:inventory:route:idx_partn": {
       "avg_drain_rate": 0,
       "avg_item_size": 41,
       "avg_scan_latency": 0,
@@ -684,7 +751,7 @@ Result of <<index-example-2>>.
       "scan_bytes_read": 0,
       "total_scan_duration": 0
    },
-   "travel-sample:inventory:route:def_sourceairport_partn": {
+   "travel-sample:inventory:route:idx_partn": {
       "avg_drain_rate": 0,
       "avg_item_size": 41,
       "avg_scan_latency": 0,

--- a/src/indexes/asciidoc/dynamic/paths/get_node_stats/operation-parameters-before-id.adoc
+++ b/src/indexes/asciidoc/dynamic/paths/get_node_stats/operation-parameters-before-id.adoc
@@ -1,0 +1,1 @@
+[[_get_node_stats_parameters]]

--- a/src/indexes/asciidoc/spring/get_index_stats/http-request.adoc
+++ b/src/indexes/asciidoc/spring/get_index_stats/http-request.adoc
@@ -3,10 +3,10 @@
 Request {counter:example}: Return statistics for an index and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
-"http://localhost:9102/api/v1/stats/travel-sample.inventory.route/def_sourceairport_partn?pretty=true"
+"http://localhost:9102/api/v1/stats/travel-sample.inventory.route/idx_partn?pretty=true"
 ----
 ====
 
@@ -15,9 +15,9 @@ curl -X GET -u Administrator:password \
 Request {counter:example}: Return statistics for an index, include partitions, and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
-"http://localhost:9102/api/v1/stats/travel-sample.inventory.route/def_sourceairport_partn?partition=true&pretty=true"
+"http://localhost:9102/api/v1/stats/travel-sample.inventory.route/idx_partn?partition=true&pretty=true"
 ----
 ====

--- a/src/indexes/asciidoc/spring/get_index_stats/http-response.adoc
+++ b/src/indexes/asciidoc/spring/get_index_stats/http-response.adoc
@@ -5,7 +5,7 @@ Result of <<index-example-1>>.
 [source,json]
 ----
 {
-   "travel-sample:inventory:route:def_sourceairport_partn": {
+   "travel-sample:inventory:route:idx_partn": {
       "avg_drain_rate": 0,
       "avg_item_size": 41,
       "avg_scan_latency": 0,
@@ -156,7 +156,7 @@ Result of <<index-example-2>>.
       "scan_bytes_read": 0,
       "total_scan_duration": 0
    },
-   "travel-sample:inventory:route:def_sourceairport_partn": {
+   "travel-sample:inventory:route:idx_partn": {
       "avg_drain_rate": 0,
       "avg_item_size": 41,
       "avg_scan_latency": 0,

--- a/src/indexes/asciidoc/spring/get_keyspace_stats/http-request.adoc
+++ b/src/indexes/asciidoc/spring/get_keyspace_stats/http-request.adoc
@@ -3,7 +3,7 @@
 Request {counter:example}: Return statistics for all indexes in a scope, omit empty results, and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
 "http://localhost:9102/api/v1/stats/travel-sample.inventory?pretty=true&skipEmpty=true"
@@ -15,7 +15,7 @@ curl -X GET -u Administrator:password \
 Request {counter:example}: Return statistics for all indexes in a collection, omit empty results, and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
 "http://localhost:9102/api/v1/stats/travel-sample.inventory.airline?pretty=true&skipEmpty=true"

--- a/src/indexes/asciidoc/spring/get_keyspace_stats/http-response.adoc
+++ b/src/indexes/asciidoc/spring/get_keyspace_stats/http-response.adoc
@@ -35,7 +35,7 @@ Result of <<keyspace-example-1>>.
       "memory_used": 3880,
       "recs_on_disk": 1968
    },
-   ...
+   // ...
 }
 ----
 ====

--- a/src/indexes/asciidoc/spring/get_node_stats/http-request.adoc
+++ b/src/indexes/asciidoc/spring/get_node_stats/http-request.adoc
@@ -3,7 +3,7 @@
 Request {counter:example}: Return statistics for an index node and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
 "http://localhost:9102/api/v1/stats?pretty=true"
@@ -15,9 +15,21 @@ curl -X GET -u Administrator:password \
 Request {counter:example}: Return statistics for an index node, omit empty results, and format the output.
 
 .Curl request
-[source,shell]
+[source,sh]
 ----
 curl -X GET -u Administrator:password \
 "http://localhost:9102/api/v1/stats?skipEmpty=true&pretty=true"
+----
+====
+
+[[node-example-3,request {counter:xref}]]
+====
+Request {counter:example}: Return statistics for an index node, omit empty results, redact index names, and format the output.
+
+.Curl request
+[source,sh]
+----
+curl -X GET -u Administrator:password \
+"http://localhost:9102/api/v1/stats?skipEmpty=true&redact=true&pretty=true"
 ----
 ====

--- a/src/indexes/asciidoc/spring/get_node_stats/http-response.adoc
+++ b/src/indexes/asciidoc/spring/get_node_stats/http-response.adoc
@@ -70,7 +70,7 @@ Result of <<node-example-1>>.
       "scan_bytes_read": 0,
       "total_scan_duration": 0
    },
-   ...
+   // ...
    }
 }
 ----
@@ -87,7 +87,8 @@ Result of <<node-example-2>>.
       "indexer_state": "Active",
       "memory_quota": 536870912,
       "memory_total_storage": 14708736,
-      "memory_used": 376973312
+      "memory_used": 376973312,
+      "total_indexer_gc_pause_ns": 72809334
    },
    "travel-sample:def_airportname": {
       "avg_item_size": 73,
@@ -109,7 +110,46 @@ Result of <<node-example-2>>.
       "memory_used": 16330,
       "recs_on_disk": 7380
    },
-   ...
+   // ...
+}
+----
+====
+
+====
+Result of <<node-example-3>>.
+
+.Response 200
+[source,json]
+----
+{
+   "10862128657611330848": {
+      "avg_item_size": 73,
+      "data_size": 514623,
+      "disk_size": 872448,
+      "frag_percent": 56,
+      "initial_build_progress": 100,
+      "items_count": 1968,
+      "memory_used": 3498,
+      "recs_on_disk": 1968
+   },
+   "1358505159407317360": {
+      "avg_item_size": 59,
+      "data_size": 1083447,
+      "disk_size": 1138688,
+      "frag_percent": 56,
+      "initial_build_progress": 100,
+      "items_count": 7380,
+      "memory_used": 16330,
+      "recs_on_disk": 7380
+   },
+   // ...
+   "indexer": {
+      "indexer_state": "Active",
+      "memory_quota": 536870912,
+      "memory_total_storage": 14708736,
+      "memory_used": 376973312,
+      "total_indexer_gc_pause_ns": 72809334
+   }
 }
 ----
 ====

--- a/src/indexes/swagger/indexes.yaml
+++ b/src/indexes/swagger/indexes.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Index Statistics REST API
-  version: '7.0'
+  version: '7.1'
   description: |
     The Index Statistics REST API is provided by the Index service.
     This API enables you to get Index service statistics.
@@ -20,6 +20,7 @@ paths:
   /api/v1/stats:
     parameters:
       - $ref: "#/parameters/QueryPretty"
+      - $ref: "#/parameters/QueryRedact"
       - $ref: "#/parameters/QuerySkipEmpty"
     get:
       operationId: get_node_stats
@@ -36,6 +37,7 @@ paths:
     parameters:
       - $ref: "#/parameters/PathKeyspace"
       - $ref: "#/parameters/QueryPretty"
+      - $ref: "#/parameters/QueryRedact"
       - $ref: "#/parameters/QuerySkipEmpty"
     get:
       operationId: get_keyspace_stats
@@ -55,6 +57,7 @@ paths:
       - $ref: "#/parameters/PathIndex"
       - $ref: "#/parameters/QueryPretty"
       - $ref: "#/parameters/QueryPartition"
+      - $ref: "#/parameters/QueryRedact"
       - $ref: "#/parameters/QuerySkipEmpty"
     get:
       operationId: get_index_stats
@@ -105,6 +108,15 @@ parameters:
     required: false
     default: false
     description: Whether statistics for index partitions should be included.
+
+  QueryRedact:
+    name: redact
+    type: boolean
+    in: query
+    required: false
+    default: false
+    description: >
+      Whether keyspace and index names should be redacted in the output.
 
   QuerySkipEmpty:
     name: skipEmpty
@@ -304,6 +316,8 @@ responses:
             
             * `__keyspace__` is the bucket, scope, and collection containing the index.
             * `__index__` is the name of the index.
+
+            If the <<_get_node_stats_parameters,redact>> query parameter was set to `true`, the keyspace and index names are replaced by the index instance ID for confidentiality.
           $ref: "#/definitions/Index"
 
   Keyspace:
@@ -322,6 +336,8 @@ responses:
             
             * `__keyspace__` is the bucket, scope, and collection containing the index.
             * `__index__` is the name of the index.
+
+            If the <<_get_keyspace_stats_parameters,redact>> query parameter was set to `true`, the keyspace and index names are replaced by the index instance ID for confidentiality.
           $ref: "#/definitions/Index"
 
   Index:
@@ -342,6 +358,8 @@ responses:
             
             * `__keyspace__` is the bucket, scope, and collection containing the index.
             * `__index__` is the name of the index.
+
+            If the <<_get_index_stats_parameters,redact>> query parameter was set to `true`, the keyspace and index names are replaced by the index instance ID for confidentiality.
           $ref: "#/definitions/Index"
         Partition-__num__:
           description: |


### PR DESCRIPTION
The following draft documentation is ready for review:

* [Index Statistics API](https://simon-dew.github.io/docs-site/DOC-9831/server/current/rest-api/rest-index-stats.html) &mdash; added `redact` parameter

Docs issue: [DOC-9297](https://issues.couchbase.com/browse/DOC-9297)