### PR TITLE
DOC-10220: HTTP 413 error

### DIFF
--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -55,6 +55,8 @@ paths:
           $ref: '#/responses/Conflict'
         "410":
           $ref: '#/responses/Gone'
+        "413":
+          $ref: '#/responses/PayloadTooLarge'
         "500":
           $ref: '#/responses/InternalServerError'
         "503":
@@ -89,6 +91,8 @@ paths:
           $ref: '#/responses/Conflict'
         "410":
           $ref: '#/responses/Gone'
+        "413":
+          $ref: '#/responses/PayloadTooLarge'
         "500":
           $ref: '#/responses/InternalServerError'
         "503":
@@ -152,6 +156,11 @@ responses:
     description: >
       Internal server error.
       There was an unforeseen problem processing the request.
+
+  PayloadTooLarge:
+    description: >
+      Payload too large.
+      The query is too large for the Query Service to process.
 
   ServiceUnavailable:
     description: >


### PR DESCRIPTION
The issue mentions that this error occurs in the Query UI. I agree that we need to cover this, but applying the test _what do we actually need to cover in the user documentation?_ I think this best covered in the reference section, rather than the Query UI documentation. Users will be able to find details on the error by searching for 413.

Docs issue: [DOC-10220](https://issues.couchbase.com/browse/DOC-10220)