### PR TITLE
DOC-10887: Add documentation about the "completed" state

### DIFF
--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -43,6 +43,8 @@ ifdef::basebackend-html[]
 endif::[]
 
 
+This section describes the properties consumed and returned by this REST API.
+
 **{toc-title}**
 
 * <<_clusters>>
@@ -143,7 +145,12 @@ __optional__|The value of the query setting Scan Consistency used for the query.
 |**serviceTime** +
 __optional__|Total amount of calendar time taken to complete the query.|string (duration)
 |**state** +
-__optional__|The state of the query execution, such as completed, running, cancelled.|string
+__optional__|The state of the query execution, such as `completed`, `running`, `cancelled`.
+
+Note that the `completed` state means that the request was started and completed by the Query service, but it does not mean that it was necessarily successful.
+The request could have been successful, or completed with errors.
+
+To find requests that were successful, use this field in conjunction with the `errorCount` field: search for requests whose state is `completed` and whose error count is `0`.|string
 |**statement** +
 __optional__|The query statement being executed.|string
 |**useCBO** +

--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
@@ -6,6 +6,8 @@
 [[_paths]]
 == Resources
 
+This section describes the operations available with this REST API.
+
 **{toc-title}**
 
 * <<_configuration_resource>>

--- a/src/admin/asciidoc/extensions/definitions/document-begin-toc.adoc
+++ b/src/admin/asciidoc/extensions/definitions/document-begin-toc.adoc
@@ -1,3 +1,5 @@
+This section describes the properties consumed and returned by this REST API.
+
 **{toc-title}**
 
 * <<_clusters>>

--- a/src/admin/asciidoc/extensions/paths/document-begin-toc.adoc
+++ b/src/admin/asciidoc/extensions/paths/document-begin-toc.adoc
@@ -1,3 +1,5 @@
+This section describes the operations available with this REST API.
+
 **{toc-title}**
 
 * <<_configuration_resource>>

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -651,7 +651,13 @@ definitions:
         description: Total amount of calendar time taken to complete the query.
       state:
         type: string
-        description: The state of the query execution, such as completed, running, cancelled.
+        description: |
+          The state of the query execution, such as `completed`, `running`, `cancelled`.
+
+          Note that the `completed` state means that the request was started and completed by the Query service, but it does not mean that it was necessarily successful.
+          The request could have been successful, or completed with errors.
+
+          To find requests that were successful, use this field in conjunction with the `errorCount` field: search for requests whose state is `completed` and whose error count is `0`.
       statement:
         type: string
         description: The query statement being executed.


### PR DESCRIPTION
This pull request adds information about successfully completed requests to the [Admin REST API](https://docs.couchbase.com/server/current/n1ql/n1ql-rest-api/admin.html#_requests) documentation.

See [couchbase/docs-server#3157](https://github.com/couchbase/docs-server/pull/3157) for changes to the `system:completed_requests` documentation.

Docs issue: DOC-10887