### PR TITLE
DOC-11429 - Making updates to reflect actual behaviour of memory quota properties

### DIFF
--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1411,8 +1411,12 @@ definitions:
           Specify `0` (the default value) to disable.
           When disabled, there is no quota.
 
-          Within a transaction, this setting enforces the memory quota for the transaction.
-          The transaction memory quota tracks only the delta table and the transaction log (approximately).
+          This parameter enforces a ceiling on the memory used for the tracked documents required for 
+          processing a request. It does not take into account any other memory that might be used to 
+          process a request, such as the stack, the operators, or some intermediate values.
+          
+          Within a transaction, this setting enforces the memory quota for the transaction by tracking the
+          delta table and the transaction log (approximately).
 
           The {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -368,8 +368,12 @@ definitions:
           Specify `0` (the default value) to disable.
           When disabled, there is no quota.
 
-          Within a transaction, this parameter enforces the memory quota for the transaction.
-          The transaction memory quota tracks only the delta table and the transaction log (approximately).
+          This parameter enforces a ceiling on the memory used for the tracked documents required for 
+          processing a request. It does not take into account any other memory that might be used to 
+          process a request, such as the stack, the operators, or some intermediate values.
+          
+          Within a transaction, this setting enforces the memory quota for the transaction by tracking the
+          delta table and the transaction log (approximately).
 
           The {memory-quota-srv}[node-level] `memory-quota` setting specifies the ceiling for this parameter for a single node.
           If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -239,8 +239,12 @@ definitions:
           [[queryMemoryQuota]]
           Specifies the maximum amount of memory a request may use on any Query node in the cluster, in MB.
 
-          Within a transaction, this setting enforces the memory quota for the transaction.
-          The transaction memory quota tracks only the delta table and the transaction log (approximately).
+          This parameter enforces a ceiling on the memory used for the tracked documents required for 
+          processing a request. It does not take into account any other memory that might be used to 
+          process a request, such as the stack, the operators, or some intermediate values.
+          
+          Within a transaction, this setting enforces the memory quota for the transaction by tracking the
+          delta table and the transaction log (approximately).
 
           The {memory-quota-srv}[node-level] `memory-quota` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.


### PR DESCRIPTION
Based on a customer issue, updates needed to be made to the OpenAPI specs for the queryMemoryQuota, memory-quota, and memory_quota parameters to reflect their actual behaviour. 