### PR TITLE
DOC-11553: Allow n1ql-feat-ctrl in hex at node level

### DIFF
--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1446,9 +1446,9 @@ definitions:
           In addition, the {numatrs_req}[request-level] `numatrs` parameter specifies this property per request.
           The minimum of that and the node-level `numatrs` setting is applied.
       n1ql-feat-ctrl:
-        type:
-          - string
-          - integer
+        type: integer
+        # type should be [string, integer] but swagger2markup cannot process
+        # fix with move to Redocly / openapi-generator
         format: int32
         default: 76
         example: "0x1"

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1446,13 +1446,17 @@ definitions:
           In addition, the {numatrs_req}[request-level] `numatrs` parameter specifies this property per request.
           The minimum of that and the node-level `numatrs` setting is applied.
       n1ql-feat-ctrl:
-        type: integer
+        type:
+          - string
+          - integer
         format: int32
         default: 76
+        example: "0x1"
         description: |
           [[n1ql-feat-ctrl]]
           {sqlpp} feature control.
           This setting is provided for technical support only.
+          The value may be an integer, or a string representing a hexadecimal number.
 
           The {queryN1qlFeatCtrl}[cluster-level] `queryN1qlFeatCtrl` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -248,12 +248,16 @@ definitions:
           In addition, there is a {memory_quota_req}[request-level] `memory_quota` parameter.
           If a request includes this parameter, it will be capped by the node-level `memory-quota` setting.
       queryN1qlFeatCtrl:
-        type: integer
+        type:
+          - string
+          - integer
         format: int32
+        example: "0x1"
         description: |
           [[queryN1qlFeatCtrl]]
           {sqlpp} feature control.
           This setting is provided for technical support only.
+          The value may be an integer, or a string representing a hexadecimal number.
 
           The {n1ql-feat-ctrl}[node-level] `n1ql-feat-ctrl` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -248,16 +248,12 @@ definitions:
           In addition, there is a {memory_quota_req}[request-level] `memory_quota` parameter.
           If a request includes this parameter, it will be capped by the node-level `memory-quota` setting.
       queryN1qlFeatCtrl:
-        type:
-          - string
-          - integer
+        type: integer
         format: int32
-        example: "0x1"
         description: |
           [[queryN1qlFeatCtrl]]
           {sqlpp} feature control.
           This setting is provided for technical support only.
-          The value may be an integer, or a string representing a hexadecimal number.
 
           The {n1ql-feat-ctrl}[node-level] `n1ql-feat-ctrl` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.


### PR DESCRIPTION
Docs issue: DOC-11553

In the Query Settings REST API, specifies that `n1ql-feat-ctrl` may be an integer or a hexadecimal string.

Swagger2Markup does not allows a property type to be an array, e.g. `[string, integer]`, so the functionality is explained in the description of the `n1ql-feat-ctrl` property. We will have to fix the property type when we move to OpenAPI 3.x with Redocly / openapi-generator.