### PR TITLE
DOC-10867: Add use replica parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
-        maven { url 'http://oss.jfrog.org/artifactory/oss-snapshot-local/' }
+        maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
         //mavenLocal()
     }
     dependencies {
@@ -23,8 +23,8 @@ repositories {
     mavenCentral()
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.9'
+wrapper {
+    gradleVersion = '7.3'
 }
 
 defaultTasks 'admin:convertSwagger2markup', 'query-service:convertSwagger2markup', 'query-settings:convertSwagger2markup', 'functions:convertSwagger2markup', 'indexes:convertSwagger2markup', 'analytics-service:convertSwagger2markup', 'analytics-config:convertSwagger2markup', 'analytics-admin:convertSwagger2markup', 'analytics-links:convertSwagger2markup', 'analytics-library:convertSwagger2markup', 'analytics-settings:convertSwagger2markup'

--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -108,7 +108,7 @@ __optional__|The HTTPS URL of the query endpoint.|string
 |Name|Description|Schema
 |**clientContextID** +
 __optional__|The opaque ID or context provided by the client.
-Refer to the {client_context_id}[request-level] `client_context_id` parameter for more information.|string
+Refer to the <<client_context_id,request-level>> `client_context_id` parameter for more information.|string
 |**elapsedTime** +
 __optional__|The time taken from when the request was acknowledged by the service to when the request was completed.
 It includes the time taken by the service to schedule the request.|string (duration)
@@ -121,13 +121,13 @@ This property is only returned if a memory quota is set for the query.|integer
 __optional__|IP address and port number of the node where the query is executed.|string
 |**phaseCounts** +
 __optional__|Count of documents processed at selective phases involved in the query execution.
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#profile[Attribute Profile in Query Response] for more details and examples.|object
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#profile[Attribute Profile in Query Response] for more details and examples.|object
 |**phaseOperators** +
 __optional__|Indicates the number of each kind of query operators involved in different phases of the query processing.
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#profile[Attribute Profile in Query Response] for more details and examples.|object
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#profile[Attribute Profile in Query Response] for more details and examples.|object
 |**phaseTimes** +
 __optional__|Cumulative execution times for various phases involved in the query execution.
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#profile[Attribute Profile in Query Response] for more details and examples.|object
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#profile[Attribute Profile in Query Response] for more details and examples.|object
 |**remoteAddr** +
 __optional__|IP address and port number of the client application, from where the query is received.|string
 |**requestId** +
@@ -451,44 +451,44 @@ __optional__|The standard deviation.|number
 |===
 |Name|Description|Schema
 |**atrcollection** +
-__optional__|[[atrcollection-srv]]
-Specifies the collection where xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] are stored.
+__optional__|[#atrcollection-srv]
+Specifies the collection where link:/server/7.6/learn/data/transactions.html#active-transaction-record-entries[active transaction records] are stored.
 The collection must be present.
 If not specified, the active transaction record is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
 
-The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
-If any part of the path contains a special character, that part of the path must be delimited in backticks `pass:c[``]`.
+The value must be a string in the form `&quot;bucket.scope.collection&quot;` or `&quot;namespace:bucket.scope.collection&quot;`.
+If any part of the path contains a special character, that part of the path must be delimited in backticks &grave;&grave;.
 
-The {atrcollection_req}[request-level] `atrcollection` parameter specifies this property per request.
+The <<atrcollection_req,request-level>> `atrcollection` parameter specifies this property per request.
 If a request does not include this parameter, the node-level `atrcollection` setting will be used. +
 **Default** : `""` +
-**Example** : `"pass:c[default:`travel-sample`.transaction.test]"`|string
+**Example** : `"default:&grave;travel-sample&grave;.transaction.test"`|string
 |**auto-prepare** +
-__optional__|[[auto-prepare]]
-Specifies whether the query engine should create a prepared statement every time a N1QL request is submitted, whether the PREPARE statement is included or not.
+__optional__|[#auto-prepare]
+Specifies whether the query engine should create a prepared statement every time a SQL++ request is submitted, whether the PREPARE statement is included or not.
 
-Refer to xref:n1ql:n1ql-language-reference/prepare.adoc#auto-prepare[Auto-Prepare] for more information. +
+Refer to link:/server/7.6/n1ql/n1ql-language-reference/prepare.html#auto-prepare[Auto-Prepare] for more information. +
 **Default** : `false` +
 **Example** : `true`|boolean
 |**cleanupclientattempts** +
-__optional__|[[cleanupclientattempts]]
+__optional__|[#cleanupclientattempts]
 When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
 
-The {queryCleanupClientAttempts}[cluster-level] `queryCleanupClientAttempts` setting specifies this property for the whole cluster.
+The <<queryCleanupClientAttempts,cluster-level>> `queryCleanupClientAttempts` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `true` +
 **Example** : `false`|boolean
 |**cleanuplostattempts** +
-__optional__|[[cleanuplostattempts]]
+__optional__|[#cleanuplostattempts]
 When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
 
-The {queryCleanupLostAttempts}[cluster-level] `queryCleanupLostAttempts` setting specifies this property for the whole cluster.
+The <<queryCleanupLostAttempts,cluster-level>> `queryCleanupLostAttempts` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `true` +
 **Example** : `false`|boolean
 |**cleanupwindow** +
-__optional__|[[cleanupwindow]]
-Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for cleanup.
+__optional__|[#cleanupwindow]
+Specifies how frequently the Query service checks its subset of link:/server/7.6/learn/data/transactions.html#active-transaction-record-entries[active transaction records] for cleanup.
 Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
 
 The value for this setting is a string.
@@ -502,133 +502,129 @@ Valid units are:
 * `m` (minutes)
 * `h` (hours)
 
-The {queryCleanupWindow}[cluster-level] `queryCleanupWindow` setting specifies this property for the whole cluster.
+The <<queryCleanupWindow,cluster-level>> `queryCleanupWindow` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `"60s"` +
 **Example** : `"30s"`|string (duration)
 |**completed** +
-__optional__|[[completed]]
+__optional__|[#completed]
 A nested object that sets the parameters for the completed requests catalog.
 All completed requests that match these parameters are tracked in the completed requests catalog.
 
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples. +
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config[Configure the Completed Requests] for more information and examples. +
 **Example** : `{
   "user" : "marco",
   "error" : 12003
 }`|<<_logging_parameters,Logging parameters>>
 |**completed-limit** +
-__optional__|[[completed-limit]]
+__optional__|[#completed-limit]
 Sets the number of requests to be logged in the completed requests catalog.
 As new completed requests are added, old ones are removed.
 
 Increase this when the completed request keyspace is not big enough to track the slow requests, such as when you want a larger sample of slow requests.
 
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples.
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config[Configure the Completed Requests] for more information and examples.
 
-The {queryCompletedLimit}[cluster-level] `queryCompletedLimit` setting specifies this property for the whole cluster.
+The <<queryCompletedLimit,cluster-level>> `queryCompletedLimit` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `4000` +
 **Example** : `7000`|integer (int32)
 |**completed-threshold** +
-__optional__|[[completed-threshold]]
+__optional__|[#completed-threshold]
 A duration in milliseconds.
 All completed queries lasting longer than this threshold are logged in the completed requests catalog.
 
 Specify `0` to track all requests, independent of duration.
 Specify any negative number to track none.
 
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples.
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config[Configure the Completed Requests] for more information and examples.
 
-The {queryCompletedThreshold}[cluster-level] `queryCompletedThreshold` setting specifies this property for the whole cluster.
+The <<queryCompletedThreshold,cluster-level>> `queryCompletedThreshold` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `1000` +
 **Example** : `7000`|integer (int32)
 |**controls** +
-__optional__|[[controls-srv]]
+__optional__|[#controls-srv]
 Specifies if there should be a controls section returned with the request results.
 
 When set to `true`, the query response document includes a controls section with runtime information provided along with the request, such as positional and named parameters or settings.
 
-[NOTE]
-If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
+NOTE: If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
 
-The {controls_req}[request-level] `controls` parameter specifies this property per request.
+The <<controls_req,request-level>> `controls` parameter specifies this property per request.
 If a request does not include this parameter, the node-level `controls` setting will be used. +
 **Default** : `false` +
 **Example** : `true`|boolean
 |**cpuprofile** +
-__optional__|[[cpuprofile]]
+__optional__|[#cpuprofile]
 The absolute path and filename to write the CPU profile to a local file.
 
 The output file includes a controls section and performance measurements, such as memory allocation and garbage collection, to pinpoint bottlenecks and ways to improve your code execution.
 
-To stop `cpuprofile`, run with the empty setting of `""`.
+NOTE: If `cpuprofile` is left running too long, it can slow the system down as its file size increases.
 
-[NOTE]
-If `cpuprofile` is left running too long, it can slow the system down as its file size increases.
-
-// +
+To stop `cpuprofile`, run with the empty setting of `&quot;&quot;`. +
 **Default** : `""` +
 **Example** : `"/tmp/info.txt"`|string
 |**debug** +
-__optional__|[[debug]]
+__optional__|[#debug]
 Use debug mode.
 
 When set to `true`, extra logging is provided. +
 **Default** : `false` +
 **Example** : `true`|boolean
 |**distribute** +
-__optional__|[[distribute]]
+__optional__|[#distribute]
 This field is only available with the POST method.
 When specified alongside other settings, this field instructs the node that is processing the request to cascade those settings to all other query nodes.
 The actual value of this field is ignored. +
 **Example** : `true`|boolean
 |**functions-limit** +
-__optional__|[[functions-limit]]
+__optional__|[#functions-limit]
 Maximum number of user-defined functions. +
 **Default** : `16384` +
 **Example** : `7000`|integer (int32)
 |**keep-alive-length** +
-__optional__|[[keep-alive-length]]
+__optional__|[#keep-alive-length]
 Maximum size of buffered result. +
 **Default** : `16384` +
 **Example** : `7000`|integer (int32)
 |**loglevel** +
-__optional__|[[loglevel]]
+__optional__|[#loglevel]
 Log level used in the logger.
 
-All values, in descending order of data:{blank}
+All values, in descending order of data:
 
-`DEBUG` -- For developers.
+* `DEBUG` &mdash; For developers.
 Writes everything.
 
-`TRACE` -- For developers.
+* `TRACE` &mdash; For developers.
 Less info than `DEBUG`.
 
-`INFO` -- For admin & customers.
-Lists warnings & errors.
+* `INFO` &mdash; For admin &amp; customers.
+Lists warnings &amp; errors.
 
-`WARN` -- For admin.
+* `WARN` &mdash; For admin.
 Only abnormal items.
 
-`ERROR` -- For admin.
+* `ERROR` &mdash; For admin.
 Only errors to be fixed.
 
-`SEVERE` -- For admin.
+* `SEVERE` &mdash; For admin.
 Major items, like crashes.
 
-`NONE` -- Doesn’t write anything.
+* `NONE` &mdash; Doesn't write anything.
 
-The {queryLogLevel}[cluster-level] `queryLogLevel` setting specifies this property for the whole cluster.
+The <<queryLogLevel,cluster-level>> `queryLogLevel` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `"INFO"` +
 **Example** : `"DEBUG"`|enum (DEBUG, TRACE, INFO, WARN, ERROR, SEVERE, NONE)
 |**max-index-api** +
-__optional__|[[max-index-api]]
+__optional__|[#max-index-api]
 Max index API.
 This setting is provided for technical support only.|integer (int32)
 |**max-parallelism** +
-__optional__|[[max-parallelism-srv]]
+__optional__|[#max-parallelism-srv]
 Specifies the maximum parallelism for queries on this node.
 
 If the value is zero or negative, the maximum parallelism is restricted to the number of allowed cores.
@@ -638,20 +634,19 @@ Similarly, if the value is greater than the number of allowed cores, the maximum
 In Community Edition, the number of allowed cores cannot be greater than 4.
 In Enterprise Edition, there is no limit to the number of allowed cores.)
 
-The {queryMaxParallelism}[cluster-level] `queryMaxParallelism` setting specifies this property for the whole cluster.
+The <<queryMaxParallelism,cluster-level>> `queryMaxParallelism` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, there is a {max_parallelism_req}[request-level] `max_parallelism` parameter.
+In addition, there is a <<max_parallelism_req,request-level>> `max_parallelism` parameter.
 If a request includes this parameter, it will be capped by the node-level `max-parallelism` setting.
 
-[NOTE]
-To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
+NOTE: To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
 
-Refer to xref:n1ql:n1ql-language-reference/index-partitioning.adoc#max-parallelism[Max Parallelism] for more information. +
+Refer to link:/server/7.6/n1ql/n1ql-language-reference/index-partitioning.html#max-parallelism[Max Parallelism] for more information. +
 **Default** : `1` +
 **Example** : `0`|integer (int32)
 |**memory-quota** +
-__optional__|[[memory-quota-srv]]
+__optional__|[#memory-quota-srv]
 Specifies the maximum amount of memory a request may use on this node, in MB.
 Note that the overall node memory quota is this setting multiplied by the <<servicers,node-level>> `servicers` setting.
 
@@ -661,137 +656,133 @@ When disabled, there is no quota.
 Within a transaction, this setting enforces the memory quota for the transaction.
 The transaction memory quota tracks only the delta table and the transaction log (approximately).
 
-The {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies this property for the whole cluster.
+The <<queryMemoryQuota,cluster-level>> `queryMemoryQuota` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {memory_quota_req}[request-level] `memory_quota` parameter specifies this property per request.
+In addition, the <<memory_quota_req,request-level>> `memory_quota` parameter specifies this property per request.
 If a request includes this parameter, it will be capped by the node-level `memory-quota` setting. +
 **Default** : `0` +
 **Example** : `4`|integer (int32)
 |**memprofile** +
-__optional__|[[memprofile]]
+__optional__|[#memprofile]
 Filename to write the diagnostic memory usage log.
 
-To stop `memprofile`, run with the empty setting of `""`.
+NOTE: If `memprofile` is left running too long, it can slow the system down as its file size increases.
 
-[NOTE]
-If `memprofile` is left running too long, it can slow the system down as its file size increases.
-
-// +
+To stop `memprofile`, run with the empty setting of `&quot;&quot;`. +
 **Default** : `""` +
 **Example** : `"/tmp/memory-usage.log"`|string
 |**mutexprofile** +
-__optional__|[[mutexprofile]]
+__optional__|[#mutexprofile]
 Mutex profile.
 This setting is provided for technical support only. +
 **Default** : `false`|boolean
 |**n1ql-feat-ctrl** +
-__optional__|[[n1ql-feat-ctrl]]
-{sqlpp} feature control.
+__optional__|[#n1ql-feat-ctrl]
+SQL++ feature control.
 This setting is provided for technical support only.
 The value may be an integer, or a string representing a hexadecimal number.
 
-The {queryN1qlFeatCtrl}[cluster-level] `queryN1qlFeatCtrl` setting specifies this property for the whole cluster.
+The <<queryN1qlFeatCtrl,cluster-level>> `queryN1qlFeatCtrl` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `76` +
 **Example** : `"0x1"`|integer (int32)
 |**numatrs** +
-__optional__|[[numatrs-srv]]
-Specifies the total number of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records].
+__optional__|[#numatrs-srv]
+Specifies the total number of link:/server/7.6/learn/data/transactions.html#active-transaction-record-entries[active transaction records].
 
-The {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies this property for the whole cluster.
+The <<queryNumAtrs,cluster-level>> `queryNumAtrs` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {numatrs_req}[request-level] `numatrs` parameter specifies this property per request.
+In addition, the <<numatrs_req,request-level>> `numatrs` parameter specifies this property per request.
 The minimum of that and the node-level `numatrs` setting is applied.|string
 |**pipeline-batch** +
-__optional__|[[pipeline-batch-srv]]
+__optional__|[#pipeline-batch-srv]
 Controls the number of items execution operators can batch for Fetch from the KV.
 
-The {queryPipelineBatch}[cluster-level] `queryPipelineBatch` setting specifies this property for the whole cluster.
+The <<queryPipelineBatch,cluster-level>> `queryPipelineBatch` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {pipeline_batch_req}[request-level] `pipeline_batch` parameter specifies this property per request.
+In addition, the <<pipeline_batch_req,request-level>> `pipeline_batch` parameter specifies this property per request.
 The minimum of that and the node-level `pipeline-batch` setting is applied. +
 **Default** : `16` +
 **Example** : `64`|integer (int32)
 |**pipeline-cap** +
-__optional__|[[pipeline-cap-srv]]
+__optional__|[#pipeline-cap-srv]
 Maximum number of items each execution operator can buffer between various operators.
 
-The {queryPipelineCap}[cluster-level] `queryPipelineCap` setting specifies this property for the whole cluster.
+The <<queryPipelineCap,cluster-level>> `queryPipelineCap` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {pipeline_cap_req}[request-level] `pipeline_cap` parameter specifies this property per request.
+In addition, the <<pipeline_cap_req,request-level>> `pipeline_cap` parameter specifies this property per request.
 The minimum of that and the node-level `pipeline-cap` setting is applied. +
 **Default** : `512` +
 **Example** : `1024`|integer (int32)
 |**plus-servicers** +
-__optional__|[[plus-servicers]]
+__optional__|[#plus-servicers]
 The number of service threads for transactions where the scan consistency is `request_plus` or `at_plus`.
 The default is 16 times the number of logical cores. +
 **Example** : `16`|integer (int32)
 |**prepared-limit** +
-__optional__|[[prepared-limit]]
+__optional__|[#prepared-limit]
 Maximum number of prepared statements in the cache.
 When this cache reaches the limit, the least recently used prepared statements will be discarded as new prepared statements are created.
 
-The {queryPreparedLimit}[cluster-level] `queryPreparedLimit` setting specifies this property for the whole cluster.
+The <<queryPreparedLimit,cluster-level>> `queryPreparedLimit` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `16384` +
 **Example** : `65536`|integer (int32)
 |**pretty** +
-__optional__|[[pretty-srv]]
+__optional__|[#pretty-srv]
 Specifies whether query results are returned in pretty format.
 
-The {pretty_req}[request-level] `pretty` parameter specifies this property per request.
+The <<pretty_req,request-level>> `pretty` parameter specifies this property per request.
 If a request does not include this parameter, the node-level setting is used, which defaults to `false`. +
 **Default** : `false` +
 **Example** : `true`|boolean
 |**profile** +
-__optional__|[[profile-srv]]
+__optional__|[#profile-srv]
 Specifies if there should be a profile section returned with the request results.
-The valid values are:{blank}
+The valid values are:
 
-`off` -- No profiling information is added to the query response.
+* `off` &mdash; No profiling information is added to the query response.
 
-`phases` -- The query response includes a profile section with stats and details about various phases of the query plan and execution.
+* `phases` &mdash; The query response includes a profile section with stats and details about various phases of the query plan and execution.
 Three phase times will be included in the `system:active_requests` and `system:completed_requests` monitoring keyspaces.
 
-`timings` -- Besides the phase times, the profile section of the query response document will include a full query plan with timing and information about the number of processed documents at each phase.
+* `timings` &mdash; Besides the phase times, the profile section of the query response document will include a full query plan with timing and information about the number of processed documents at each phase.
 This information will be included in the `system:active_requests` and `system:completed_requests` keyspaces.
 
-[NOTE]
-If `profile` is not set as one of the above values, then the profile setting does not change.
+NOTE: If `profile` is not set as one of the above values, then the profile setting does not change.
 
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#monitor-profile-details[Monitoring and Profiling Details] for more information and examples.
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#monitor-profile-details[Monitoring and Profiling Details] for more information and examples.
 
-The {profile_req}[request-level] `profile` parameter specifies this property per request.
+The <<profile_req,request-level>> `profile` parameter specifies this property per request.
 If a request does not include this parameter, the node-level `profile` setting will be used. +
 **Default** : `"off"` +
 **Example** : `"phases"`|enum (off, phases, timings)
 |**request-size-cap** +
-__optional__|[[request-size-cap]]
+__optional__|[#request-size-cap]
 Maximum size of a request. +
 **Default** : `67108864` +
 **Example** : `70000`|integer (int32)
 |**scan-cap** +
-__optional__|[[scan-cap-srv]]
+__optional__|[#scan-cap-srv]
 Maximum buffered channel size between the indexer client and the query service for index scans.
 This parameter controls when to use scan backfill.
 
 Use `0` or a negative number to disable.
 Smaller values reduce GC, while larger values reduce indexer backfill.
 
-The {queryScanCap}[cluster-level] `queryScanCap` setting specifies this property for the whole cluster.
+The <<queryScanCap,cluster-level>> `queryScanCap` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {scan_cap_req}[request-level] `scan_cap` parameter specifies this property per request.
+In addition, the <<scan_cap_req,request-level>> `scan_cap` parameter specifies this property per request.
 The minimum of that and the node-level `scan-cap` setting is applied. +
 **Default** : `512` +
 **Example** : `1024`|integer (int32)
 |**servicers** +
-__optional__|[[servicers]]
+__optional__|[#servicers]
 The number of service threads for the query.
 The default is 4 times the number of cores on the query node.
 
@@ -799,7 +790,7 @@ Note that the overall node memory quota is this setting multiplied by the <<memo
 **Default** : `32` +
 **Example** : `8`|integer (int32)
 |**timeout** +
-__optional__|[[timeout-srv]]
+__optional__|[#timeout-srv]
 Maximum time to spend on the request before timing out (ns).
 
 The value for this setting is an integer, representing a duration in nanoseconds.
@@ -808,17 +799,17 @@ It must not be delimited by quotes, and must not include a unit.
 Specify `0` (the default value) or a negative integer to disable.
 When disabled, no timeout is applied and the request runs for however long it takes.
 
-The {queryTimeout}[cluster-level] `queryTimeout` setting specifies this property for the whole cluster.
+The <<queryTimeout,cluster-level>> `queryTimeout` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {timeout_req}[request-level] `timeout` parameter specifies this property per request.
+In addition, the <<timeout_req,request-level>> `timeout` parameter specifies this property per request.
 The minimum of that and the node-level `timeout` setting is applied. +
 **Default** : `0` +
 **Example** : `500000000`|integer (int64)
 |**txtimeout** +
-__optional__|[[txtimeout-srv]]
+__optional__|[#txtimeout-srv]
 Maximum time to spend on a transaction before timing out (ns).
-This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
+This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the <<tximplicit,tximplicit>> parameter is set.
 For all other requests, it is ignored.
 
 The value for this setting is an integer, representing a duration in nanoseconds.
@@ -827,24 +818,47 @@ It must not be delimited by quotes, and must not include a unit.
 Specify `0` (the default value) to disable.
 When disabled, no timeout is applied and the transaction runs for however long it takes.
 
-The {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies this property for the whole cluster.
+The <<queryTxTimeout,cluster-level>> `queryTxTimeout` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {txtimeout_req}[request-level] `txtimeout` parameter specifies this property per request.
+In addition, the <<txtimeout_req,request-level>> `txtimeout` parameter specifies this property per request.
 The minimum of that and the node-level `txtimeout` setting is applied. +
 **Default** : `0` +
 **Example** : `500000000`|integer (int64)
 |**use-cbo** +
-__optional__|[[use-cbo-srv]]
+__optional__|[#use-cbo-srv]
 Specifies whether the cost-based optimizer is enabled.
 
-The {queryUseCBO}[cluster-level] `queryUseCBO` setting specifies this property for the whole cluster.
+The <<queryUseCBO,cluster-level>> `queryUseCBO` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
+In addition, the <<use_cbo_req,request-level>> `use_cbo` parameter specifies this property per request.
 If a request does not include this parameter, the node-level setting is used, which defaults to `true`. +
 **Default** : `true` +
 **Example** : `false`|boolean
+|**use-replica** +
+__optional__|[#use-replica-srv]
+Specifies whether a query can fetch data from a replica vBucket if active vBuckets are inaccessible.
+The possible values are:
+
+* `off` &mdash; read from replica is disabled for all queries and cannot be overridden at request level.
+
+* `on` &mdash; read from replica is enabled for all queries, but can be disabled at request level.
+
+* `unset` &mdash; read from replica is enabled or disabled at request level.
+
+The <<queryUseReplica,cluster-level>> `queryUseReplica` setting specifies the default for this property for the whole cluster.
+When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+In addition, the <<use_replica_req,request-level>> `use_replica` parameter specifies this property per request.
+If a request does not include this parameter, or if the request-level parameter is `unset`, the node-level setting is used.
+If the request-level parameter and the node-level setting are both `unset`, read from replica is disabled for that request.
+
+WARNING: Do not enable read from replica when you require consistent results.
+
+SELECT queries within a transaction cannot read from replica. +
+**Default** : `"unset"` +
+**Example** : `"true"`|enum (off, on, unset)
 |===
 
 [[_logging_parameters]]
@@ -865,7 +879,7 @@ If specified, all completed requests from this IP address are logged. +
 __optional__|The opaque ID or context provided by the client.
 If specified, all completed requests with this client context ID are logged.
 
-Refer to the {client_context_id}[request-level] `client_context_id` parameter for more information.|string
+Refer to the <<client_context_id,request-level>> `client_context_id` parameter for more information.|string
 |**error** +
 __optional__|An error number.
 If specified, all completed queries returning this error number are logged. +
@@ -873,14 +887,14 @@ If specified, all completed queries returning this error number are logged. +
 |**tag** +
 __optional__|A unique string which tags a set of qualifiers.
 
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information. +
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config[Configure the Completed Requests] for more information. +
 **Default** : `""` +
 **Example** : `"both_user_and_error"`|string
 |**threshold** +
 __optional__|A duration in milliseconds.
 If specified, all completed queries lasting longer than this threshold are logged.
 
-This is another way of specifying the {completed-threshold-srv}[node-level] `completed-threshold` setting. +
+This is another way of specifying the <<completed-threshold,node-level>> `completed-threshold` setting. +
 **Default** : `1000` +
 **Example** : `7000`|integer (int32)
 |**user** +

--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/overview.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/overview.adoc
@@ -13,12 +13,12 @@
 The Admin REST API is a secondary API provided by the Query service.
 This API enables you to retrieve statistics about the clusters and nodes running the Query service; view or specify node-level settings; and view or delete requests.
 
-The API schemes and host URLs are as follows:{blank}
+The API schemes and host URLs are as follows:
 
-* `+http://node:8093/+`
-* `+https://node:18093/+` (for secure access)
+* http://node:8093/
+* https://node:18093/ (for secure access)
 
-where [.var]`node` is the host name or IP address of a computer running the Query service.
+where `node` is the host name or IP address of a computer running the Query service.
 
 
 === Version information

--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
@@ -226,10 +226,8 @@ GET /admin/prepareds
 
 ===== Description
 Returns all prepared statements.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Prepared Statements] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-get[Get Prepared Statements] for examples.
 
 
 ===== Responses
@@ -259,10 +257,8 @@ GET /admin/prepareds/{name}
 
 ===== Description
 Returns the specified prepared statement.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Prepared Statements] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-get[Get Prepared Statements] for examples.
 
 
 ===== Parameters
@@ -303,10 +299,8 @@ DELETE /admin/prepareds/{name}
 
 ===== Description
 Deletes the specified prepared statement.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-delete[Delete Prepared Statements] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-delete[Delete Prepared Statements] for examples.
 
 
 ===== Parameters
@@ -348,11 +342,9 @@ GET /admin/indexes/prepareds
 
 ===== Description
 Returns all prepared index statements.
-[TIP]
-====
-* Use <<_get_prepared>> to get information about a prepared index statement.
-* Use <<_delete_prepared>> to delete a prepared index statement.
-====
+
+* Use <<_get_prepared,Retrieve a Prepared Statement>> to get information about a prepared index statement.
+* Use <<_delete_prepared,Delete a Prepared Statement>> to delete a prepared index statement.
 
 
 ===== Responses
@@ -393,10 +385,8 @@ GET /admin/active_requests
 
 ===== Description
 Returns all active query requests.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Active Requests] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-get[Get Active Requests] for examples.
 
 
 ===== Responses
@@ -426,10 +416,8 @@ GET /admin/active_requests/{request}
 
 ===== Description
 Returns the specified active query request.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Active Requests] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-get[Get Active Requests] for examples.
 
 
 ===== Parameters
@@ -470,10 +458,8 @@ DELETE /admin/active_requests/{request}
 
 ===== Description
 Terminates the specified active query request.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-delete[Terminate an Active Request] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-delete[Terminate an Active Request] for examples.
 
 
 ===== Parameters
@@ -515,11 +501,9 @@ GET /admin/indexes/active_requests
 
 ===== Description
 Returns all active index requests.
-[TIP]
-====
-* Use <<_get_active_request>> to get information about an active index request.
-* Use <<_delete_active_request>> to terminate an active index request.
-====
+
+* Use <<_get_active_request,Retrieve an Active Request>> to get information about an active index request.
+* Use <<_delete_active_request,Delete an Active Request>> to terminate an active index request.
 
 
 ===== Responses
@@ -560,10 +544,8 @@ GET /admin/completed_requests
 
 ===== Description
 Returns all completed requests.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Completed Requests] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-get[Get Completed Requests] for examples.
 
 
 ===== Responses
@@ -593,10 +575,8 @@ GET /admin/completed_requests/{request}
 
 ===== Description
 Returns the specified completed request.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Completed Requests] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-get[Get Completed Requests] for examples.
 
 
 ===== Parameters
@@ -637,10 +617,8 @@ DELETE /admin/completed_requests/{request}
 
 ===== Description
 Purges the specified completed request.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-delete[Purge the Completed Requests] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-delete[Purge the Completed Requests] for examples.
 
 
 ===== Parameters
@@ -682,11 +660,9 @@ GET /admin/indexes/completed_requests
 
 ===== Description
 Returns all completed index requests.
-[TIP]
-====
-* Use <<_get_completed_request>> to get information about a completed index request.
-* Use <<_delete_completed_request>> to purge a completed index request.
-====
+
+* Use <<_get_completed_request,Retrieve a Completed Request>> to get information about a completed index request.
+* Use <<_delete_completed_request,Delete a Completed Request>> to purge a completed index request.
 
 
 ===== Responses
@@ -728,10 +704,8 @@ GET /admin/vitals
 ===== Description
 Returns data about the running state and health of the query engine.
 This information can be very useful to assess the current workload and performance characteristics of a query engine, and hence load-balance the requests being sent to various query engines.
-[NOTE]
-====
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#vitals[Get System Vitals] for examples.
-====
+
+NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#vitals[Get System Vitals] for examples.
 
 
 ===== Responses
@@ -841,7 +815,7 @@ Currently unused.
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**302**|Redirects to the <<_get_stats>> endpoint.|text/html
+|**302**|Redirects to the <<_get_stats,Retrieve All Statistics>> endpoint.|string (text/html)
 |===
 
 
@@ -889,10 +863,8 @@ GET /admin/settings
 
 ===== Description
 Returns node-level query settings.
-[NOTE]
-====
-Refer to xref:settings:query-settings.adoc[Query Settings] for more information.
-====
+
+NOTE: Refer to link:../../settings/query-settings.html[Query Settings] for more information.
 
 
 ===== Responses
@@ -922,10 +894,8 @@ POST /admin/settings
 
 ===== Description
 Updates node-level query settings.
-[NOTE]
-====
-Refer to xref:settings:query-settings.adoc[Query Settings] for more information.
-====
+
+NOTE: Refer to link:../../settings/query-settings.html[Query Settings] for more information.
 
 
 ===== Parameters

--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
@@ -227,8 +227,6 @@ GET /admin/prepareds
 ===== Description
 Returns all prepared statements.
 
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-get[Get Prepared Statements] for examples.
-
 
 ===== Responses
 
@@ -248,6 +246,11 @@ NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-pr
 |===
 
 
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Prepared Statements] for examples.
+
+
 [[_get_prepared]]
 ==== Retrieve a Prepared Statement
 ....
@@ -257,8 +260,6 @@ GET /admin/prepareds/{name}
 
 ===== Description
 Returns the specified prepared statement.
-
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-get[Get Prepared Statements] for examples.
 
 
 ===== Parameters
@@ -290,6 +291,11 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 |===
 
 
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Prepared Statements] for examples.
+
+
 [[_delete_prepared]]
 ==== Delete a Prepared Statement
 ....
@@ -299,8 +305,6 @@ DELETE /admin/prepareds/{name}
 
 ===== Description
 Deletes the specified prepared statement.
-
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-delete[Delete Prepared Statements] for examples.
 
 
 ===== Parameters
@@ -331,6 +335,11 @@ This may be a UUID that was assigned automatically, or a name that was user-spec
 |Type|Name
 |**basic**|**<<_default,Default>>**
 |===
+
+
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-delete[Delete Prepared Statements] for examples.
 
 
 [[_get_prepared_indexes]]
@@ -386,8 +395,6 @@ GET /admin/active_requests
 ===== Description
 Returns all active query requests.
 
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-get[Get Active Requests] for examples.
-
 
 ===== Responses
 
@@ -407,6 +414,11 @@ NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-ac
 |===
 
 
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Active Requests] for examples.
+
+
 [[_get_active_request]]
 ==== Retrieve an Active Request
 ....
@@ -416,8 +428,6 @@ GET /admin/active_requests/{request}
 
 ===== Description
 Returns the specified active query request.
-
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-get[Get Active Requests] for examples.
 
 
 ===== Parameters
@@ -449,6 +459,11 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Active Requests] for examples.
+
+
 [[_delete_active_request]]
 ==== Delete an Active Request
 ....
@@ -458,8 +473,6 @@ DELETE /admin/active_requests/{request}
 
 ===== Description
 Terminates the specified active query request.
-
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-delete[Terminate an Active Request] for examples.
 
 
 ===== Parameters
@@ -490,6 +503,11 @@ This is the `requestID` that was assigned automatically when the statement was c
 |Type|Name
 |**basic**|**<<_default,Default>>**
 |===
+
+
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-delete[Terminate an Active Request] for examples.
 
 
 [[_get_active_indexes]]
@@ -545,8 +563,6 @@ GET /admin/completed_requests
 ===== Description
 Returns all completed requests.
 
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-get[Get Completed Requests] for examples.
-
 
 ===== Responses
 
@@ -566,6 +582,11 @@ NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-co
 |===
 
 
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Completed Requests] for examples.
+
+
 [[_get_completed_request]]
 ==== Retrieve a Completed Request
 ....
@@ -575,8 +596,6 @@ GET /admin/completed_requests/{request}
 
 ===== Description
 Returns the specified completed request.
-
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-get[Get Completed Requests] for examples.
 
 
 ===== Parameters
@@ -608,6 +627,11 @@ This is the `requestID` that was assigned automatically when the statement was c
 |===
 
 
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Completed Requests] for examples.
+
+
 [[_delete_completed_request]]
 ==== Delete a Completed Request
 ....
@@ -617,8 +641,6 @@ DELETE /admin/completed_requests/{request}
 
 ===== Description
 Purges the specified completed request.
-
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-delete[Purge the Completed Requests] for examples.
 
 
 ===== Parameters
@@ -649,6 +671,11 @@ This is the `requestID` that was assigned automatically when the statement was c
 |Type|Name
 |**basic**|**<<_default,Default>>**
 |===
+
+
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-delete[Purge the Completed Requests] for examples.
 
 
 [[_get_completed_indexes]]
@@ -705,8 +732,6 @@ GET /admin/vitals
 Returns data about the running state and health of the query engine.
 This information can be very useful to assess the current workload and performance characteristics of a query engine, and hence load-balance the requests being sent to various query engines.
 
-NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#vitals[Get System Vitals] for examples.
-
 
 ===== Responses
 
@@ -724,6 +749,11 @@ NOTE: Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#vitals
 |Type|Name
 |**basic**|**<<_default,Default>>**
 |===
+
+
+===== Example HTTP request
+
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#vitals[Get System Vitals] for examples.
 
 
 [[_get_stats]]
@@ -864,7 +894,8 @@ GET /admin/settings
 ===== Description
 Returns node-level query settings.
 
-NOTE: Refer to link:../../settings/query-settings.html[Query Settings] for more information.
+
+NOTE: Refer to xref:settings:query-settings.adoc[] for more information.
 
 
 ===== Responses
@@ -895,7 +926,8 @@ POST /admin/settings
 ===== Description
 Updates node-level query settings.
 
-NOTE: Refer to link:../../settings/query-settings.html[Query Settings] for more information.
+
+NOTE: Refer to xref:settings:query-settings.adoc[] for more information.
 
 
 ===== Parameters

--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/security.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/security.adoc
@@ -17,7 +17,7 @@ __Type__ : basic
 
 [[_none]]
 === None
-No authentication is required for the <<_get_ping>> or <<_get_debug_vars>> endpoints.
+No authentication is required for the <<_get_ping,Ping>> or <<_get_debug_vars,Get Debug Variables>> endpoints.
 
 [%hardbreaks]
 __Type__ : basic

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
@@ -61,62 +61,62 @@ This section describes the properties consumed and returned by this REST API.
 |===
 |Name|Description|Schema
 |**args** +
-__optional__|[[args]]
+__optional__|[#args]
 Applicable if the statement has 1 or more positional parameters.
 
 An array of JSON values, one for each positional parameter in the statement.
 
 Note that positional parameters apply to `prepared` also.
 
-Refer to {section_srh_tlm_n1b}[] for details. +
+Refer to link:/server/7.6/settings/query-settings.html#section_srh_tlm_n1b[Named Parameters and Positional Parameters] for details. +
 **Example** : `[ "LAX", 6 ]`|< object > array
 |**atrcollection** +
-__optional__|[[atrcollection_req]]
-Specifies the collection where the {transactions-understanding-transactions}[active transaction record] (ATR) is stored.
+__optional__|[#atrcollection_req]
+Specifies the collection where the link:/server/7.6/learn/data/transactions.html#active-transaction-record-entries[active transaction record] (ATR) is stored.
 The collection must be present.
 If not specified, the ATR is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
 
-The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
-If any part of the path contains a special character, that part of the path must be delimited in backticks `&grave;&grave;`.
+The value must be a string in the form `&quot;bucket.scope.collection&quot;` or `&quot;namespace:bucket.scope.collection&quot;`.
+If any part of the path contains a special character, that part of the path must be delimited in backticks &grave;&grave;.
 
-The {atrcollection-srv}[node-level] `atrcollection` setting specifies the default for this parameter for a single node.
+The <<atrcollection-srv,node-level>> `atrcollection` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting. +
 **Example** : `"default:&grave;travel-sample&grave;.transaction.test"`|string
 |**auto_execute** +
-__optional__|[[auto_execute]]
+__optional__|[#auto_execute]
 Specifies that prepared statements should be executed automatically as soon as they are created.
 This saves you from having to make two separate requests in cases where you want to prepare a statement and execute it immediately.
 
-Refer to {prepare-auto-execute}[Auto-Execute] for more information. +
+Refer to link:/server/7.6/n1ql/n1ql-language-reference/prepare.html#auto-execute[Auto-Execute] for more information. +
 **Default** : `false` +
 **Example** : `true`|boolean
 |**client_context_id** +
-__optional__|[[client_context_id]]
+__optional__|[#client_context_id]
 A piece of data supplied by the client that is echoed in the response, if present.
-{sqlpp} is agnostic about the content of this parameter; it is just echoed in the response.
+SQL++ is agnostic about the content of this parameter; it is just echoed in the response.
 
 * Maximum allowed size is 64 characters; all others will be cut.
-* If it contains an escape character `/` or quote `"`, it will be rejected as error code 1110.|string
+* If it contains an escape character `/` or quote `&quot;`, it will be rejected as error code 1110.|string
 |**compression** +
-__optional__|[[compression]]
+__optional__|[#compression]
 Compression format to use for response data on the wire.
 
 Values are case-insensitive. +
 **Default** : `"NONE"` +
 **Example** : `"zip"`|enum (ZIP, RLE, LZMA, LZO, NONE)
 |**controls** +
-__optional__|[[controls_req]]
+__optional__|[#controls_req]
 Specifies if there should be a controls section returned with the request results.
 
 When set to `true`, the query response document includes a controls section with runtime information provided along with the request, such as positional and named parameters or settings.
 
 If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
 
-The {controls-srv}[node-level] `controls` setting specifies the default for this parameter for a single node.
+The <<controls-srv,node-level>> `controls` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting. +
 **Example** : `true`|boolean
 |**creds** +
-__optional__|[[creds]]
+__optional__|[#creds]
 Specifies the login credentials.
 The Query API supports two types of identity: local (or bucket) and admin.
 
@@ -132,37 +132,37 @@ If credentials are supplied in the request header, then HTTP Basic Authenticatio
   "pass" : "password"
 } ]`|< <<_credentials,Credentials>> > array
 |**durability_level** +
-__optional__|[[durability_level]]
-The level of {durability}[durability] for mutations produced by the request.
+__optional__|[#durability_level]
+The level of link:/server/7.6/learn/data/durability.html[durability] for mutations produced by the request.
 
-If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the {tximplicit}[tximplicit] parameter set to `true`, the durability level is specified for all mutations within that transaction.
+If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the <<tximplicit,tximplicit>> parameter set to `true`, the durability level is specified for all mutations within that transaction.
 
 Durability is also supported for non-transactional DML statements.
 In this case, the `kvtimeout` parameter is used as the durability timeout.
 
-If not specified, the default durability level is `"majority"`.
-Set the durability level to `"none"` or `""` to specify no durability. +
+If not specified, the default durability level is `&quot;majority&quot;`.
+Set the durability level to `&quot;none&quot;` or `&quot;&quot;` to specify no durability. +
 **Default** : `"majority"` +
-**Example** : `"none"`|enum ("", none, majority, majorityAndPersistActive, persistToMajority)
+**Example** : `"none"`|enum (&quot;&quot;, none, majority, majorityAndPersistActive, persistToMajority)
 |**encoded_plan** +
-__optional__|[[encoded_plan]]
+__optional__|[#encoded_plan]
 In Couchbase Server 6.5 and later, this parameter is ignored and has no effect.
 It is included for compatibility with previous versions of Couchbase Server.|string
 |**encoding** +
-__optional__|[[encoding]]
+__optional__|[#encoding]
 Desired character encoding for the query results.
 
 Only possible value is `UTF-8` and is case-insensitive. +
 **Default** : `"UTF-8"`|string
 |**format** +
-__optional__|[[format]]
+__optional__|[#format]
 Desired format for the query results.
 
 Values are case-insensitive. +
 **Default** : `"JSON"` +
 **Example** : `"XML"`|enum (JSON, XML, CSV, TSV)
 |**kvtimeout** +
-__optional__|[[kvtimeout]]
+__optional__|[#kvtimeout]
 The maximum time to wait for a KV operation before timing out.
 Only applies to statements within a transaction, or to non-transactional statements when the `durability_level` is set.
 
@@ -182,15 +182,15 @@ When disabled, no timeout is applied and the KV operation runs for however long 
 **Default** : `"2.5s"` +
 **Example** : `"10ms"`|string
 |**max_parallelism** +
-__optional__|[[max_parallelism_req]]
+__optional__|[#max_parallelism_req]
 Specifies the maximum parallelism for the query.
 
-The {max-parallelism-srv}[node-level] `max-parallelism` setting specifies the ceiling for this parameter for a single node.
+The <<max-parallelism-srv,node-level>> `max-parallelism` setting specifies the ceiling for this parameter for a single node.
 If the request-level parameter is zero or negative, the parallelism for the query is set to the node-level setting.
 If the request-level parameter is greater than zero and less than the node-level setting, the request-level parameter overrides the node-level setting.
 If the request-level parameter is greater than the node-level setting, the parallelism for the query is set to the node-level setting.
 
-In addition, the {queryMaxParallelism}[cluster-level] `queryMaxParallelism` setting specifies the ceiling for this parameter for the whole cluster.
+In addition, the <<queryMaxParallelism,cluster-level>> `queryMaxParallelism` setting specifies the ceiling for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
@@ -198,7 +198,7 @@ To enable queries to run in parallel, you must specify the cluster-level `queryM
 The default value is the same as the number of partitions of the index selected for the query. +
 **Example** : `3`|integer (int32)
 |**memory_quota** +
-__optional__|[[memory_quota_req]]
+__optional__|[#memory_quota_req]
 Specifies the maximum amount of memory the request may use, in MB.
 
 Specify `0` (the default value) to disable.
@@ -207,65 +207,65 @@ When disabled, there is no quota.
 Within a transaction, this parameter enforces the memory quota for the transaction.
 The transaction memory quota tracks only the delta table and the transaction log (approximately).
 
-The {memory-quota-srv}[node-level] `memory-quota` setting specifies the ceiling for this parameter for a single node.
+The <<memory-quota-srv,node-level>> `memory-quota` setting specifies the ceiling for this parameter for a single node.
 If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.
 If the node-level setting is greater than zero, the request-level parameter is capped by the node-level setting.
 
-In addition, the {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies the ceiling for this parameter for the whole cluster.
+In addition, the <<queryMemoryQuota,cluster-level>> `queryMemoryQuota` setting specifies the ceiling for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
 **Default** : `0` +
 **Example** : `4`|integer (int32)
 |**metrics** +
-__optional__|[[metrics]]
+__optional__|[#metrics]
 Specifies that metrics should be returned with query results. +
 **Default** : `true` +
 **Example** : `false`|boolean
 |**namespace** +
-__optional__|[[namespace]] Specifies the namespace to use. Currently, only the `default` namespace is available. +
+__optional__|Specifies the namespace to use. Currently, only the `default` namespace is available. +
 **Example** : `"default"`|string
 |**numatrs** +
-__optional__|[[numatrs_req]]
-Specifies the total number of {transactions-understanding-transactions}[active transaction records].
+__optional__|[#numatrs_req]
+Specifies the total number of link:/server/7.6/learn/data/transactions.html#active-transaction-record-entries[active transaction records].
 Must be a positive integer.
 
-The {numatrs-srv}[node-level] `numatrs` setting specifies the default for this parameter for a single node.
+The <<numatrs-srv,node-level>> `numatrs` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
-In addition, the {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
+In addition, the <<queryNumAtrs,cluster-level>> `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
 **Default** : `1024` +
 **Example** : `512`|integer (int32)
 |**pipeline_batch** +
-__optional__|[[pipeline_batch_req]]
+__optional__|[#pipeline_batch_req]
 Controls the number of items execution operators can batch for Fetch from the KV.
 
-The {pipeline-batch-srv}[node-level] `pipeline-batch` setting specifies the default for this parameter for a single node.
+The <<pipeline-batch-srv,node-level>> `pipeline-batch` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
-In addition, the {queryPipelineBatch}[cluster-level] `queryPipelineBatch` setting specifies the default for this parameter for the whole cluster.
+In addition, the <<queryPipelineBatch,cluster-level>> `queryPipelineBatch` setting specifies the default for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
 **Example** : `64`|integer (int32)
 |**pipeline_cap** +
-__optional__|[[pipeline_cap_req]]
+__optional__|[#pipeline_cap_req]
 Maximum number of items each execution operator can buffer between various operators.
 
-The {pipeline-cap-srv}[node-level] `pipeline-cap` setting specifies the default for this parameter for a single node.
+The <<pipeline-cap-srv,node-level>> `pipeline-cap` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
-In addition, the {queryPipelineCap}[cluster-level] `queryPipelineCap` setting specifies the default for this parameter for the whole cluster.
+In addition, the <<queryPipelineCap,cluster-level>> `queryPipelineCap` setting specifies the default for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
 **Example** : `1024`|integer (int32)
 |**prepared** +
-__optional__|[[prepared]]
+__optional__|[#prepared]
 _Required_ if `statement` not provided.
 
-The name of the prepared {sqlpp} statement to be executed.
-Refer to {execute}[EXECUTE] for examples.
+The name of the prepared SQL++ statement to be executed.
+Refer to link:/server/7.6/n1ql/n1ql-language-reference/execute.html[EXECUTE] for examples.
 
 If both `prepared` and `statement` are present and non-empty, an error is returned. +
 **Example** : `"[127.0.0.1:8091]pricy_hotel"`|string
 |**preserve_expiry** +
-__optional__|[[preserve_expiry]]
+__optional__|[#preserve_expiry]
 Specifies whether documents should keep their current expiration setting when modified by a DML statement.
 
 If `true`, documents will keep any existing expiration setting when modified by a DML statement.
@@ -277,34 +277,34 @@ Not supported for statements in a transaction. +
 **Default** : `false` +
 **Example** : `true`|boolean
 |**pretty** +
-__optional__|[[pretty_req]]
+__optional__|[#pretty_req]
 Specifies the query results returned in pretty format.
 
-The {pretty-srv}[node-level] `pretty` setting specifies the default for this parameter for a single node.
+The <<pretty-srv,node-level>> `pretty` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting. +
 **Example** : `false`|boolean
 |**profile** +
-__optional__|[[profile_req]]
+__optional__|[#profile_req]
 Specifies if there should be a profile section returned with the request results.
 The valid values are:
 
-`off`:: No profiling information is added to the query response.
+* `off` &mdash; No profiling information is added to the query response.
 
-`phases`::
+* `phases` &mdash;
 The query response includes a profile section with stats and details about various phases of the query plan and execution.
 Three phase times will be included in the `system:active_requests` and `system:completed_requests` monitoring keyspaces.
 
-`timings`::
+* `timings` &mdash;
 Besides the phase times, the profile section of the query response document will include a full query plan with timing and information about the number of processed documents at each phase.
 This information will be included in the `system:active_requests` and `system:completed_requests` keyspaces.
 
 If `profile` is not set as one of the above values, then the profile setting does not change.
 
-The {profile-srv}[node-level] `profile` setting specifies the default for this parameter for a single node.
+The <<profile-srv,node-level>> `profile` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting. +
 **Example** : `"phases"`|enum (off, phases, timings)
 |**query_context** +
-__optional__|[[query_context]]
+__optional__|[#query_context]
 Specifies the namespace, bucket, and scope used to resolve partial keyspace references within the request.
 
 The query context may be a _full path_, containing namespace, bucket, and scope; or a _relative path_, containing just the bucket and scope.
@@ -313,7 +313,7 @@ If the namespace name is omitted, the default namespace in the current session i
 **Default** : `"default:"` +
 **Example** : `"default:travel-sample.inventory"`|string
 |**readonly** +
-__optional__|[[readonly]]
+__optional__|[#readonly]
 Controls whether a query can change a resulting recordset.
 
 If `readonly` is `true`, then the following statements are not allowed:
@@ -329,42 +329,41 @@ When using GET requests, it's best to set `readonly` to `true`. +
 **Default** : `false` +
 **Example** : `true`|boolean
 |**scan_cap** +
-__optional__|[[scan_cap_req]]
+__optional__|[#scan_cap_req]
 Maximum buffered channel size between the indexer client and the query service for index scans.
 This parameter controls when to use scan backfill.
 
 Use `0` or a negative number to disable.
 Smaller values reduce GC, while larger values reduce indexer backfill.
 
-The {scan-cap-srv}[node-level] `scan-cap` setting specifies the default for this parameter for a single node.
+The <<scan-cap-srv,node-level>> `scan-cap` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
-In addition, the {queryScanCap}[cluster-level] `queryScanCap` setting specifies the default for this parameter for the whole cluster.
+In addition, the <<queryScanCap,cluster-level>> `queryScanCap` setting specifies the default for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
 **Example** : `1024`|integer (int32)
 |**scan_consistency** +
-__optional__|[[scan_consistency]]
+__optional__|[#scan_consistency]
 Specifies the consistency guarantee or constraint for index scanning.
 The valid values are:
 
-`not_bounded`::
+* `not_bounded` &mdash;
 No timestamp vector is used in the index scan.
 This is the fastest mode, because it avoids the costs of obtaining the vector and waiting for the index to catch up to the vector.
 
-`at_plus`::
+* `at_plus` &mdash;
 This implements bounded consistency.
 The request includes a `scan_vector` parameter and value, which is used as a lower bound.
 This can be used to implement read-your-own-writes (RYOW).
 
-`request_plus`::
+* `request_plus` &mdash;
 This implements strong consistency per request.
 Before processing the request, a current vector is obtained.
 The vector is used as a lower bound for the statements in the request.
 If there are DML statements in the request, RYOW is also applied within the request.
-+
-If `request_plus` is specified in a query that runs during a failover of an index node, the query waits until the rebalance operation completes and the index data has rebalanced before returning a result.
+(If `request_plus` is specified in a query that runs during a failover of an index node, the query waits until the rebalance operation completes and the index data has rebalanced before returning a result.)
 
-`statement_plus`::
+* `statement_plus` &mdash;
 This implements strong consistency per statement.
 Before processing each statement, a current vector is obtained and used as a lower bound for that statement.
 
@@ -373,25 +372,25 @@ Values are case-insensitive.
 For multi-statement requests, the default behavior is RYOW within each request.
 If you want to disable RYOW within a request, add a separate `request_consistency` parameter that can be set to `not_bounded`.
 
-If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the {tximplicit}[tximplicit] parameter set to `true`, then this parameter sets the transactional scan consistency.
-Refer to {transactional-scan-consistency}[Transactional Scan Consistency] for details. +
+If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the <<tximplicit,tximplicit>> parameter set to `true`, then this parameter sets the transactional scan consistency.
+Refer to link:/server/7.6/settings/query-settings.html#transactional-scan-consistency[Transactional Scan Consistency] for details. +
 **Default** : `"not_bounded"` +
 **Example** : `"at_plus"`|enum (not_bounded, at_plus, request_plus, statement_plus)
 |**scan_vector** +
-__optional__|[[scan_vector]]
+__optional__|[#scan_vector]
 _Required_ if `scan_consistency` is `at_plus` and `scan_vectors` not provided.
 
 Specify the lower bound vector timestamp for one keyspace when using `at_plus` scan consistency.
 
-Scan vectors are built of two-element +[+[.var]`value`, [.var]`guard`] entries:
+Scan vectors are built of two-element [`value`, `guard`] entries:
 
-* [.var]`value`: a vBucket's sequence number (a JSON number)
-* [.var]`guard`: a vBucket's UUID (a string)
+* `value`: a vBucket's sequence number (a JSON number)
+* `guard`: a vBucket's UUID (a string)
 
 Scan vectors have two forms:
 
-. *Full scan vector*: an array of +[+[.var]`value`, [.var]`guard`] entries, giving an entry for every vBucket in the system.
-. *Sparse scan vectors*: an object providing entries for specific vBuckets, mapping a vBucket number (a string) to each +[+[.var]`value`, [.var]`guard`] entry.
+. Full: an array of [`value`, `guard`] entries, giving an entry for every vBucket in the system.
+. Sparse: an object providing entries for specific vBuckets, mapping a vBucket number (a string) to each [`value`, `guard`] entry.
 
 Note that `scan_vector` can only be used if the query uses at most one keyspace; if it is used for a query referencing more than one keyspace, the query will fail with an error.
 
@@ -401,7 +400,7 @@ For queries referencing multiple keyspaces, use `scan_vectors`. +
   "19" : [ 47574574, "VB19ID" ]
 }`|object
 |**scan_vectors** +
-__optional__|[[scan_vectors]]
+__optional__|[#scan_vectors]
 _Required_ if `scan_consistency` is `at_plus` and `scan_vector` not provided.
 
 A map from keyspace names to scan vectors.
@@ -409,7 +408,7 @@ See `scan_vector`.
 
 The scan vectors can be Full or Sparse.|object
 |**scan_wait** +
-__optional__|[[scan_wait]]
+__optional__|[#scan_wait]
 Can be supplied with `scan_consistency` values of `request_plus`, `statement_plus` and `at_plus`.
 
 Specifies the maximum time the client is willing to wait for an index to catch up to the vector timestamp in the request.
@@ -431,15 +430,15 @@ Specify `0` or a negative integer to disable. +
 **Default** : `""` +
 **Example** : `"30m"`|string (duration)
 |**signature** +
-__optional__|[[signature]]
+__optional__|[#signature]
 Include a header for the results schema in the response. +
 **Default** : `true` +
 **Example** : `false`|boolean
 |**statement** +
-__optional__|[[statement]]
+__optional__|[#statement]
 _Required_ if `prepared` not provided.
 
-Any valid {sqlpp} statement for a POST request, or a read-only {sqlpp} statement (SELECT, EXPLAIN) for a GET request.
+Any valid SQL++ statement for a POST request, or a read-only SQL++ statement (SELECT, EXPLAIN) for a GET request.
 
 If both `prepared` and `statement` are present and non-empty, an error is returned.
 
@@ -452,7 +451,7 @@ To avoid this, either URL-encode the semicolon as `%3B`, or just omit the semico
 This restriction does not apply when specifying the request parameters in JSON format. +
 **Example** : `"SELECT * FROM &grave;travel-sample&grave;.inventory.hotel LIMIT 1"`|string
 |**timeout** +
-__optional__|[[timeout_req]]
+__optional__|[#timeout_req]
 Maximum time to spend on the request before timing out.
 
 The value for this parameter is a string.
@@ -469,22 +468,22 @@ Valid units are:
 Specify a duration of `0` or a negative duration to disable.
 When disabled, no timeout is applied and the request runs for however long it takes.
 
-If {txid}[txid] or {tximplicit}[tximplicit] is set, this parameter is ignored.
+If <<tximplicit,tximplicit>> or <<txid,txid>> is set, this parameter is ignored.
 The request inherits the remaining time of the transaction as timeout.
 
-The {timeout-srv}[node-level] `timeout` setting specifies the default for this parameter for a single node.
+The <<timeout-srv,node-level>> `timeout` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 However, if the node-level setting is greater than 0, the timeout for the query is limited to the node-level setting.
 
-In addition, the {queryTimeout}[cluster-level] `queryTimeout` setting specifies the default for this parameter for the whole cluster.
+In addition, the <<queryTimeout,cluster-level>> `queryTimeout` setting specifies the default for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
 **Example** : `"30m"`|string (duration)
 |**txdata** +
-__optional__|[[txdata]]
+__optional__|[#txdata]
 Transaction data.
 For internal use only.|object
 |**txid** +
-__optional__|[[txid]]
+__optional__|[#txid]
 _Required_ for statements within a transaction.
 
 Transaction ID.
@@ -495,29 +494,29 @@ The transaction ID should be the same as the transaction ID generated by the `BE
 The transaction must be active and non-expired. +
 **Example** : `"d81d9b4a-b758-4f98-b007-87ba262d3a51"`|string (UUID)
 |**tximplicit** +
-__optional__|[[tximplicit]]
+__optional__|[#tximplicit]
 Specifies that a DML statement is a singleton transaction.
 
 When this parameter is true, the Query service starts a transaction and executes the statement.
 If execution is successful, the Query service commits the transaction; otherwise the transaction is rolled back.
 
 The statement may not be part of an ongoing transaction.
-If the {txid}[txid] request-level parameter is set, the `tximplicit` parameter is ignored. +
+If the <<txid,txid>> request-level parameter is set, the `tximplicit` parameter is ignored. +
 **Default** : `false` +
 **Example** : `true`|boolean
 |**txstmtnum** +
-__optional__|[[txstmtnum]]
+__optional__|[#txstmtnum]
 Transaction statement number.
 The transaction statement number must be a positive integer, and must be higher than any previous transaction statement numbers in the transaction.
 If the transaction statement number is lower than the transaction statement number for any previous statement, an error is generated. +
 **Example** : `10`|integer (int32)
 |**txtimeout** +
-__optional__|[[txtimeout_req]]
+__optional__|[#txtimeout_req]
 Maximum time to spend on a transaction before timing out.
-Only applies to `BEGIN TRANSACTION` statements, or DML statements for which {tximplicit}[tximplicit] is set.
+Only applies to `BEGIN TRANSACTION` statements, or DML statements for which <<tximplicit,tximplicit>> is set.
 For other statements, it is ignored.
 
-Within a transaction, the request-level {timeout_req}[timeout] parameter is ignored.
+Within a transaction, the request-level <<timeout_req,timeout>> parameter is ignored.
 The transaction timeout clock starts when the `BEGIN WORK` statement is successful.
 Once the transaction timeout is reached, no statement is allowed to continue in the transaction.
 
@@ -535,28 +534,28 @@ Valid units are:
 Specify a duration of `0` to disable.
 When disabled, the request-level timeout is set to the default.
 
-The {txtimeout-srv}[node-level] `txtimeout` setting specifies the default for this parameter for a single node.
+The <<txtimeout-srv,node-level>> `txtimeout` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
 
-In addition, the {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
+In addition, the <<queryTxTimeout,cluster-level>> `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-The default is `"15s"` for cbq files or scripts, `"2m"` for interactive cbq sessions or redirected input. +
+The default is `&quot;15s&quot;` for cbq files or scripts, `&quot;2m&quot;` for interactive cbq sessions or redirected input. +
 **Example** : `"30m"`|string (duration)
 |**use_cbo** +
-__optional__|[[use_cbo_req]]
+__optional__|[#use_cbo_req]
 Specifies whether the cost-based optimizer is enabled.
 
-The {use-cbo-srv}[node-level] `use-cbo` setting specifies the default for this parameter for a single node.
+The <<use-cbo-srv,node-level>> `use-cbo` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
-In addition, the {queryUseCBO}[cluster-level] `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
+In addition, the <<queryUseCBO,cluster-level>> `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
 **Example** : `true`|boolean
 |**use_fts** +
-__optional__|[[use_fts]]
-[.edition]#{enterprise}#
+__optional__|[#use_fts]
+&blacktriangleright; https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
 
 Specifies that the query should use a full-text index.
 
@@ -566,23 +565,47 @@ If the query does not contain a `USING FTS` hint, and this parameter is set to t
 If a qualified full-text index is available, it is selected for the query.
 If none of the available full-text indexes are qualified, the available GSI indexes are considered instead.
 
-Refer to {flex-indexes}[Flex Indexes] for more information. +
+Refer to link:/server/7.6/n1ql/n1ql-language-reference/flex-indexes.html[Flex Indexes] for more information. +
 **Default** : `false` +
 **Example** : `true`|boolean
+|**use_replica** +
+__optional__|[#use_replica_req]
+Specifies whether a query can fetch data from a replica vBucket if active vBuckets are inaccessible.
+The possible values are:
+
+* `off` &mdash; read from replica is disabled for this request.
+
+* `on` &mdash; read from replica is enabled for this request, unless it has been disabled for all requests at node level.
+
+* `unset` &mdash; read from replica is specified by the node-level setting.
+If the node-level setting is also `unset`, read from replica is disabled for this request.
+
+The <<use-replica-srv,node-level>> `use-replica` setting specifies the default for this property for a single node.
+The request-level parameter usually overrides the node-level setting.
+However, when the node-level setting is `off`, the request-level parameter cannot enable the property.
+
+In addition, the <<queryUseReplica,cluster-level>> `queryUseReplica` setting specifies the default for this property for the whole cluster.
+When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+WARNING: Do not enable read from replica when you require consistent results.
+
+SELECT queries within a transaction cannot read from replica. +
+**Default** : `"unset"` +
+**Example** : `"true"`|enum (off, on, unset)
 |**$<identifier>** +
-__optional__|[[identifier]]
+__optional__|[#identifier]
 Applicable if the `statement` has 1 or more named parameters.
 
 The name of a named parameter consists of two parts:
 
-. The $ character
+. The `$` character.
 . An identifier that starts with an alpha character followed by one or more alphanumeric characters.
 
 The value of the named parameter is any JSON value.
 
 Named parameters apply to `prepared` also.
 
-Refer to {section_srh_tlm_n1b}[] for details.|string (any JSON value)
+Refer to link:/server/7.6/settings/query-settings.html#section_srh_tlm_n1b[Named Parameters and Positional Parameters] for details.|string (any JSON value)
 |===
 
 
@@ -619,7 +642,7 @@ The response body has the following structure.
 |**requestID** +
 __optional__|A unique identifier for the response.|string (UUID)
 |**clientContextID** +
-__optional__|The client context ID of the request, if one was supplied &mdash; see `client_context_id` in {request-parameters}[].|string
+__optional__|The client context ID of the request, if one was supplied &mdash; see `client_context_id` in <<_request_parameters,Request Parameters>>.|string
 |**signature** +
 __optional__|The schema of the results. Present only when the query completes successfully. +
 **Example** : `{
@@ -636,7 +659,7 @@ __optional__|An array of 0 or more warning objects. If a warning occurred during
 |**metrics** +
 __optional__|An object containing metrics about the request.|<<_metrics,Metrics>>
 |**controls** +
-__optional__|An object containing runtime information provided along with the request. Present only if `controls` was set to true in the {request-parameters}[].|<<_controls,Controls>>
+__optional__|An object containing runtime information provided along with the request. Present only if `controls` was set to true in the <<_request_parameters,Request Parameters>>.|<<_controls,Controls>>
 |===
 
 
@@ -656,12 +679,12 @@ __required__|A message describing the error or warning in detail. This property 
 __optional__|Unique name that has a 1:1 mapping to the code. Uniquely identifies the condition. This property is helpful for pattern matching and can have meaning, making it more memorable than the code. The name should be fully qualified. +
 **Example** : `"indexing.scan.io_failure"`|string
 |**sev** +
-__optional__|One of the following {sqlpp} severity levels, listed in order of severity:
+__optional__|One of the following SQL++ severity levels, listed in order of severity:
 
- 1. Severe
- 2. Error
- 3. Warn
- 4. Info|integer
+. Severe
+. Error
+. Warn
+. Info|integer
 |**temp** +
 __optional__|Indicates if the condition is transient &mdash; for example, the queue is full. If the value is `false`, it tells clients and users that a retry without modification produces the same condition.|boolean
 |===
@@ -690,7 +713,7 @@ __optional__|The number of mutations that were made during the request.|integer 
 |**sortCount** +
 __optional__|The number of objects that were sorted. Present only if the request includes `ORDER BY`.
 
-If a query includes ORDER BY, LIMIT, or OFFSET clauses, an application can use the `sortCount` value to give the overall number of results in a message such as `"page 1 of N"`.|integer (unsigned)
+If a query includes ORDER BY, LIMIT, or OFFSET clauses, an application can use the `sortCount` value to give the overall number of results in a message such as `&quot;page 1 of N&quot;`.|integer (unsigned)
 |**usedMemory** +
 __optional__|The amount of document memory used to execute the request. This property is only returned if a memory quota was set for the query.|integer (unsigned)
 |**errorCount** +

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
@@ -62,11 +62,10 @@ This section describes the properties consumed and returned by this REST API.
 |Name|Description|Schema
 |**args** +
 __optional__|[#args]
-Applicable if the statement has 1 or more positional parameters.
+Supplies the values for positional parameters in the statement.
+Applicable if the statement or prepared statement contains 1 or more positional parameters.
 
-An array of JSON values, one for each positional parameter in the statement.
-
-Note that positional parameters apply to `prepared` also.
+The value is an array of JSON values, one for each positional parameter in the statement.
 
 Refer to link:/server/7.6/settings/query-settings.html#section_srh_tlm_n1b[Named Parameters and Positional Parameters] for details. +
 **Example** : `[ "LAX", 6 ]`|< object > array
@@ -594,16 +593,16 @@ SELECT queries within a transaction cannot read from replica. +
 **Example** : `"true"`|enum (off, on, unset)
 |**$<identifier>** +
 __optional__|[#identifier]
-Applicable if the `statement` has 1 or more named parameters.
+Supplies the value for a named parameter in the statement.
+Applicable if the statement or prepared statement contains 1 or more named parameters.
 
 The name of a named parameter consists of two parts:
 
 . The `$` character.
-. An identifier that starts with an alpha character followed by one or more alphanumeric characters.
+. An identifier that specifies the name of the parameter.
+ This must start with an alpha character, followed by one or more alphanumeric characters.
 
-The value of the named parameter is any JSON value.
-
-Named parameters apply to `prepared` also.
+The value of the named parameter can be any JSON value.
 
 Refer to link:/server/7.6/settings/query-settings.html#section_srh_tlm_n1b[Named Parameters and Positional Parameters] for details.|string (any JSON value)
 |===

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/overview.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/overview.adoc
@@ -11,12 +11,12 @@
 [[_overview]]
 == Overview
 The Query Service REST API is provided by the Query service.
-This API enables you to run {sqlpp} queries and set request-level parameters.
+This API enables you to run SQL++ queries and set request-level parameters.
 
 The API schemes and host URLs are as follows:
 
-* `http://node:8093/`
-* `https://node:18093/` (for secure access)
+* http://node:8093/
+* https://node:18093/ (for secure access)
 
 where `node` is the host name or IP address of a node running the Query service.
 

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/paths.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/paths.adoc
@@ -22,7 +22,7 @@ POST /query/service
 
 
 ==== Description
-Enables you to execute a {sqlpp} statement. This method allows you to run queries and modifying statements, and specify query parameters.
+Enables you to execute a SQL++ statement. This method allows you to run queries and modifying statements, and specify query parameters.
 
 
 ==== Parameters
@@ -50,14 +50,9 @@ This section describes the response HTTP status codes.
 |**200**|The operation was successful.|<<_response_body,Response Body>>
 |**400**|Bad Request. The request cannot be processed for one of the following reasons:
 
-
-  * The statement contains a {sqlpp} syntax error.
-
-
-  * The request has a missing or unrecognized HTTP parameter.
-
-
-  * The request is badly formatted (for example, the request body contains a JSON syntax error).|No Content
+* The statement contains a SQL++ syntax error.
+* The request has a missing or unrecognized HTTP parameter.
+* The request is badly formatted (for example, the request body contains a JSON syntax error).|No Content
 |**401**|Unauthorized. The credentials provided with the request are missing or invalid.|No Content
 |**403**|Forbidden. There is a read-only violation. Either there was an attempt to create or update in a GET request or a POST request where `readonly` is set, or the client does not have the authorization to modify an object (index, keyspace or namespace) in the statement.|No Content
 |**404**|Not found. The statement in the request references an invalid namespace or keyspace.|No Content
@@ -113,7 +108,7 @@ curl http://localhost:8093/query/service \
 Conversely, because it is sent as a JSON object, the statement in this example can contain a semicolon.
 ====
 
-For further examples, refer to {section_srh_tlm_n1b}[].
+For further examples, refer to xref:n1ql:n1ql-rest-api/examplesrest.adoc[].
 
 
 [[_get_service]]
@@ -124,7 +119,7 @@ GET /query/service
 
 
 ==== Description
-Enables you to execute a {sqlpp} statement. This method allows you to run queries and modifying statements, and specify query parameters. It does not allow you to run modifying statements.
+Enables you to execute a SQL++ statement. This method allows you to run queries and modifying statements, and specify query parameters. It does not allow you to run modifying statements.
 
 This endpoint is intended for situations where use of the `POST` method is restricted.
 
@@ -149,14 +144,9 @@ This section describes the response HTTP status codes.
 |**200**|The operation was successful.|<<_response_body,Response Body>>
 |**400**|Bad Request. The request cannot be processed for one of the following reasons:
 
-
-  * The statement contains a {sqlpp} syntax error.
-
-
-  * The request has a missing or unrecognized HTTP parameter.
-
-
-  * The request is badly formatted (for example, the request body contains a JSON syntax error).|No Content
+* The statement contains a SQL++ syntax error.
+* The request has a missing or unrecognized HTTP parameter.
+* The request is badly formatted (for example, the request body contains a JSON syntax error).|No Content
 |**401**|Unauthorized. The credentials provided with the request are missing or invalid.|No Content
 |**403**|Forbidden. There is a read-only violation. Either there was an attempt to create or update in a GET request or a POST request where `readonly` is set, or the client does not have the authorization to modify an object (index, keyspace or namespace) in the statement.|No Content
 |**404**|Not found. The statement in the request references an invalid namespace or keyspace.|No Content
@@ -193,7 +183,7 @@ curl -v http://localhost:8093/query/service?statement=SELECT%20name%20FROM%20%60
 ----
 ====
 
-For further examples, refer to {section_srh_tlm_n1b}[].
+For further examples, refer to xref:n1ql:n1ql-rest-api/examplesrest.adoc[].
 
 
 

--- a/docs/modules/rest-api/partials/query-settings/definitions.adoc
+++ b/docs/modules/rest-api/partials/query-settings/definitions.adoc
@@ -59,24 +59,24 @@ endif::[]
 |===
 |Name|Description|Schema
 |**queryCleanupClientAttempts** +
-__optional__|[[queryCleanupClientAttempts]]
+__optional__|[#queryCleanupClientAttempts]
 When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
 
-The {cleanupclientattempts}[node-level] `cleanupclientattempts` setting specifies this property for a single node.
+The <<cleanupclientattempts,node-level>> `cleanupclientattempts` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `true` +
 **Example** : `false`|boolean
 |**queryCleanupLostAttempts** +
-__optional__|[[queryCleanupLostAttempts]]
+__optional__|[#queryCleanupLostAttempts]
 When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
 
-The {cleanuplostattempts}[node-level] `cleanuplostattempts` setting specifies this property for a single node.
+The <<cleanuplostattempts,node-level>> `cleanuplostattempts` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `true` +
 **Example** : `false`|boolean
 |**queryCleanupWindow** +
-__optional__|[[queryCleanupWindow]]
-Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for cleanup.
+__optional__|[#queryCleanupWindow]
+Specifies how frequently the Query service checks its subset of link:/server/7.6/learn/data/transactions.html#active-transaction-record-entries[active transaction records] for cleanup.
 Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
 
 The value for this setting is a string.
@@ -90,69 +90,69 @@ Valid units are:
 * `m` (minutes)
 * `h` (hours)
 
-The {cleanupwindow}[node-level] `cleanupwindow` setting specifies this property for a single node.
+The <<cleanupwindow,node-level>> `cleanupwindow` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `"60s"` +
 **Example** : `"30s"`|string (duration)
 |**queryCompletedLimit** +
-__optional__|[[queryCompletedLimit]]
+__optional__|[#queryCompletedLimit]
 Sets the number of requests to be logged in the completed requests catalog.
 As new completed requests are added, old ones are removed.
 
 Increase this when the completed request keyspace is not big enough to track the slow requests, such as when you want a larger sample of slow requests.
 
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples.
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config[Configure the Completed Requests] for more information and examples.
 
-The {completed-limit-srv}[node-level] `completed-limit` setting specifies this property for a single node.
+The <<completed-limit,node-level>> `completed-limit` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `4000` +
 **Example** : `7000`|integer (int32)
 |**queryCompletedThreshold** +
-__optional__|[[queryCompletedThreshold]]
+__optional__|[#queryCompletedThreshold]
 A duration in milliseconds.
 All completed queries lasting longer than this threshold are logged in the completed requests catalog.
 
 Specify `0` to track all requests, independent of duration.
 Specify any negative number to track none.
 
-Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples.
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config[Configure the Completed Requests] for more information and examples.
 
-The {completed-threshold-srv}[node-level] `completed-threshold` setting specifies this property for a single node.
+The <<completed-threshold,node-level>> `completed-threshold` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `1000` +
 **Example** : `7000`|integer (int32)
 |**queryLogLevel** +
-__optional__|[[queryLogLevel]]
+__optional__|[#queryLogLevel]
 Log level used in the logger.
 
-All values, in descending order of data:{blank}
+All values, in descending order of data:
 
-`DEBUG` -- For developers.
+* `DEBUG` &mdash; For developers.
 Writes everything.
 
-`TRACE` -- For developers.
+* `TRACE` &mdash; For developers.
 Less info than `DEBUG`.
 
-`INFO` -- For admin & customers.
-Lists warnings & errors.
+* `INFO` &mdash; For admin &amp; customers.
+Lists warnings &amp; errors.
 
-`WARN` -- For admin.
+* `WARN` &mdash; For admin.
 Only abnormal items.
 
-`ERROR` -- For admin.
+* `ERROR` &mdash; For admin.
 Only errors to be fixed.
 
-`SEVERE` -- For admin.
+* `SEVERE` &mdash; For admin.
 Major items, like crashes.
 
-`NONE` -- Doesn’t write anything.
+* `NONE` &mdash; Doesn't write anything.
 
-The {loglevel-srv}[node-level] `loglevel` setting specifies this property for a single node.
+The <<loglevel,node-level>> `loglevel` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `"INFO"` +
 **Example** : `"DEBUG"`|enum (DEBUG, TRACE, INFO, WARN, ERROR, SEVERE, NONE)
 |**queryMaxParallelism** +
-__optional__|[[queryMaxParallelism]]
+__optional__|[#queryMaxParallelism]
 Specifies the maximum parallelism for queries on all Query nodes in the cluster.
 
 If the value is zero or negative, the maximum parallelism is restricted to the number of allowed cores.
@@ -162,99 +162,98 @@ Similarly, if the value is greater than the number of allowed cores, the maximum
 In Community Edition, the number of allowed cores cannot be greater than 4.
 In Enterprise Edition, there is no limit to the number of allowed cores.)
 
-The {max-parallelism-srv}[node-level] `max-parallelism` setting specifies this property for a single node.
+The <<max-parallelism-srv,node-level>> `max-parallelism` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, there is a {max_parallelism_req}[request-level] `max_parallelism` parameter.
+In addition, there is a <<max_parallelism_req,request-level>> `max_parallelism` parameter.
 If a request includes this parameter, it will be capped by the node-level `max-parallelism` setting.
 
-[NOTE]
-To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
+NOTE: To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
 
-Refer to xref:n1ql:n1ql-language-reference/index-partitioning.adoc#max-parallelism[Max Parallelism] for more information. +
+Refer to link:/server/7.6/n1ql/n1ql-language-reference/index-partitioning.html#max-parallelism[Max Parallelism] for more information. +
 **Default** : `1` +
 **Example** : `0`|integer (int32)
 |**queryMemoryQuota** +
-__optional__|[[queryMemoryQuota]]
+__optional__|[#queryMemoryQuota]
 Specifies the maximum amount of memory a request may use on any Query node in the cluster, in MB.
 
 Within a transaction, this setting enforces the memory quota for the transaction.
 The transaction memory quota tracks only the delta table and the transaction log (approximately).
 
-The {memory-quota-srv}[node-level] `memory-quota` setting specifies this property for a single node.
+The <<memory-quota-srv,node-level>> `memory-quota` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, there is a {memory_quota_req}[request-level] `memory_quota` parameter.
+In addition, there is a <<memory_quota_req,request-level>> `memory_quota` parameter.
 If a request includes this parameter, it will be capped by the node-level `memory-quota` setting. +
 **Default** : `0` +
 **Example** : `4`|integer (int32)
 |**queryN1qlFeatCtrl** +
-__optional__|[[queryN1qlFeatCtrl]]
-{sqlpp} feature control.
+__optional__|[#queryN1qlFeatCtrl]
+SQL++ feature control.
 This setting is provided for technical support only.
 
-The {n1ql-feat-ctrl}[node-level] `n1ql-feat-ctrl` setting specifies this property for a single node.
+The <<n1ql-feat-ctrl,node-level>> `n1ql-feat-ctrl` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.|integer (int32)
 |**queryNumAtrs** +
-__optional__|[[queryNumAtrs]]
-Specifies the total number of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for all Query nodes in the cluster.
+__optional__|[#queryNumAtrs]
+Specifies the total number of link:/server/7.6/learn/data/transactions.html#active-transaction-record-entries[active transaction records] for all Query nodes in the cluster.
 
-The {numatrs-srv}[node-level] `numatrs` setting specifies this property for a single node.
+The <<numatrs-srv,node-level>> `numatrs` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, there is a {numatrs_req}[request-level] `numatrs` parameter.
+In addition, there is a <<numatrs_req,request-level>> `numatrs` parameter.
 If a request includes this parameter, it will be capped by the node-level `numatrs` setting. +
 **Default** : `1024` +
 **Minimum value (exclusive)** : `0` +
 **Example** : `512`|integer (int32)
 |**queryPipelineBatch** +
-__optional__|[[queryPipelineBatch]]
+__optional__|[#queryPipelineBatch]
 Controls the number of items execution operators can batch for Fetch from the KV.
 
-The {pipeline-batch-srv}[node-level] `pipeline-batch` setting specifies this property for a single node.
+The <<pipeline-batch-srv,node-level>> `pipeline-batch` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {pipeline_batch_req}[request-level] `pipeline_batch` parameter specifies this property per request.
+In addition, the <<pipeline_batch_req,request-level>> `pipeline_batch` parameter specifies this property per request.
 The minimum of that and the node-level `pipeline-batch` setting is applied. +
 **Default** : `16` +
 **Example** : `64`|integer (int32)
 |**queryPipelineCap** +
-__optional__|[[queryPipelineCap]]
+__optional__|[#queryPipelineCap]
 Maximum number of items each execution operator can buffer between various operators.
 
-The {pipeline-cap-srv}[node-level] `pipeline-cap` setting specifies this property for a single node.
+The <<pipeline-cap-srv,node-level>> `pipeline-cap` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {pipeline_cap_req}[request-level] `pipeline_cap` parameter specifies this property per request.
+In addition, the <<pipeline_cap_req,request-level>> `pipeline_cap` parameter specifies this property per request.
 The minimum of that and the node-level `pipeline-cap` setting is applied. +
 **Default** : `512` +
 **Example** : `1024`|integer (int32)
 |**queryPreparedLimit** +
-__optional__|[[queryPreparedLimit]]
+__optional__|[#queryPreparedLimit]
 Maximum number of prepared statements in the cache.
 When this cache reaches the limit, the least recently used prepared statements will be discarded as new prepared statements are created.
 
-The {prepared-limit-srv}[node-level] `prepared-limit` setting specifies this property for a single node.
+The <<prepared-limit,node-level>> `prepared-limit` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `16384` +
 **Example** : `65536`|integer (int32)
 |**queryScanCap** +
-__optional__|[[queryScanCap]]
+__optional__|[#queryScanCap]
 Maximum buffered channel size between the indexer client and the query service for index scans.
 This parameter controls when to use scan backfill.
 
 Use `0` or a negative number to disable.
 Smaller values reduce GC, while larger values reduce indexer backfill.
 
-The {scan-cap-srv}[node-level] `scan-cap` setting specifies this property for a single node.
+The <<scan-cap-srv,node-level>> `scan-cap` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {scan_cap_req}[request-level] `scan_cap` parameter specifies this property per request.
+In addition, the <<scan_cap_req,request-level>> `scan_cap` parameter specifies this property per request.
 The minimum of that and the node-level `scan-cap` setting is applied. +
 **Default** : `512` +
 **Example** : `1024`|integer (int32)
 |**queryTimeout** +
-__optional__|[[queryTimeout]]
+__optional__|[#queryTimeout]
 Maximum time to spend on the request before timing out (ns).
 
 The value for this setting is an integer, representing a duration in nanoseconds.
@@ -263,17 +262,17 @@ It must not be delimited by quotes, and must not include a unit.
 Specify `0` (the default value) or a negative integer to disable.
 When disabled, no timeout is applied and the request runs for however long it takes.
 
-The {timeout-srv}[node-level] `timeout` setting specifies this property for a single node.
+The <<timeout-srv,node-level>> `timeout` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {timeout_req}[request-level] `timeout` parameter specifies this property per request.
+In addition, the <<timeout_req,request-level>> `timeout` parameter specifies this property per request.
 The minimum of that and the node-level `timeout` setting is applied. +
 **Default** : `0` +
 **Example** : `500000000`|integer (int64)
 |**queryTxTimeout** +
-__optional__|[[queryTxTimeout]]
+__optional__|[#queryTxTimeout]
 Maximum time to spend on a transaction before timing out.
-This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
+This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the <<tximplicit,tximplicit>> parameter is set.
 For all other requests, it is ignored.
 
 The value for this setting is a string.
@@ -290,24 +289,24 @@ Valid units are:
 Specify `0ms` (the default value) to disable.
 When disabled, no timeout is applied and the transaction runs for however long it takes.
 
-The {txtimeout-srv}[node-level] `txtimeout` setting specifies this property for a single node.
+The <<txtimeout-srv,node-level>> `txtimeout` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, there is a {txtimeout_req}[request-level] `txtimeout` parameter.
+In addition, there is a <<txtimeout_req,request-level>> `txtimeout` parameter.
 If a request includes this parameter, it will be capped by the node-level `txtimeout` setting. +
 **Default** : `"0ms"` +
 **Example** : `"0.5s"`|string (duration)
 |**queryTmpSpaceDir** +
-__optional__|[[queryTmpSpaceDir]]
+__optional__|[#queryTmpSpaceDir]
 The path to which the indexer writes temporary backfill files, to store any transient data during query processing.
 
 The specified path must already exist.
 Only absolute paths are allowed.
 
-The default path is [.file]`var/lib/couchbase/tmp` within the Couchbase Server installation directory. +
+The default path is `var/lib/couchbase/tmp` within the Couchbase Server installation directory. +
 **Example** : `"/opt/couchbase/var/lib/couchbase/tmp"`|string
 |**queryTmpSpaceSize** +
-__optional__|[[queryTmpSpaceSize]]
+__optional__|[#queryTmpSpaceSize]
 The maximum size of temporary backfill files (MB).
 
 Setting the size to `0` disables backfill.
@@ -317,18 +316,41 @@ The maximum size is limited only by the available disk space. +
 **Default** : `5120` +
 **Example** : `2048`|integer (int32)
 |**queryUseCBO** +
-__optional__|[[queryUseCBO]]
+__optional__|[#queryUseCBO]
 Specifies whether the cost-based optimizer is enabled.
 
-The {use-cbo-srv}[node-level] `use-cbo` setting specifies this property for a single node.
+The <<use-cbo-srv,node-level>> `use-cbo` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-In addition, the {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
+In addition, the <<use_cbo_req,request-level>> `use_cbo` parameter specifies this property per request.
 If a request does not include this parameter, the node-level setting is used, which defaults to `true`. +
 **Default** : `true` +
 **Example** : `false`|boolean
+|**queryUseReplica** +
+__optional__|[#queryUseReplica]
+Specifies whether a query can fetch data from a replica vBucket if active vBuckets are inaccessible.
+The possible values are:
+
+* `off` &mdash; read from replica is disabled for all queries and cannot be overridden at request level.
+
+* `on` &mdash; read from replica is enabled for all queries, but can be disabled at request level.
+
+* `unset` &mdash; read from replica is enabled or disabled at request level.
+
+The <<use-replica-srv,node-level>> `use-replica` setting specifies this property for a single node.
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+In addition, the <<use_replica_req,request-level>> `use_replica` parameter specifies this property per request.
+If a request does not include this parameter, or if the request-level parameter is `unset`, the node-level setting is used.
+If the request-level parameter and the node-level setting are both `unset`, read from replica is disabled for that request.
+
+WARNING: Do not enable read from replica when you require consistent results.
+
+SELECT queries within a transaction cannot read from replica. +
+**Default** : `"unset"` +
+**Example** : `"true"`|enum (off, on, unset)
 |**queryCurlWhitelist** +
-__optional__|[[queryCurlWhitelist]]
+__optional__|[#queryCurlWhitelist]
 An object which determines which URLs may be accessed by the `CURL()` function.|<<_access,Access>>
 |===
 
@@ -348,7 +370,7 @@ An object which determines which URLs may be accessed by the `CURL()` function.|
 |**all_access** +
 __required__|Defines whether the user has access to all URLs, or only URLs specified by the access list.
 
-This field set must be set to `false` to enable the [.param]`allowed_urls` and [.param]`disallowed_urls` fields.
+This field set must be set to `false` to enable the `allowed_urls` and `disallowed_urls` fields.
 
 Setting this field to `true` enables access to all endpoints. +
 **Default** : `false`|boolean
@@ -357,8 +379,8 @@ __optional__|An array of strings, each of which is a URL to which you wish to gr
 Each URL is a prefix match.
 The CURL() function will allow any URL that starts with this value.
 
-For example, if you wish to allow access to all Google APIs, add the URL `+++https://maps.googleapis.com+++` to the array.
-To allow complete access to `localhost`, use `+++http://localhost+++`.
+For example, if you wish to allow access to all Google APIs, add the URL https://maps.googleapis.com to the array.
+To allow complete access to `localhost`, use http://localhost.
 
 Note that each URL must include the port, protocol, and all other components of the URL.|< string > array
 |**disallowed_urls** +
@@ -366,7 +388,7 @@ __optional__|An array of strings, each of which is a URL that will be restricted
 Each URL is a prefix match.
 The CURL() function will disallow any URL that starts with this value.
 
-If both [.param]`allowed_urls` and [.param]`disallowed_urls` fields are populated, the [.param]`disallowed_urls` field takes precedence over [.param]`allowed_urls`.
+If both `allowed_urls` and `disallowed_urls` fields are populated, the `disallowed_urls` field takes precedence over `allowed_urls`.
 
 Note that each URL must include the port, protocol, and all other components of the URL.|< string > array
 |===

--- a/docs/modules/rest-api/partials/query-settings/overview.adoc
+++ b/docs/modules/rest-api/partials/query-settings/overview.adoc
@@ -15,8 +15,8 @@ This API enables you to view or specify cluster-level Query settings.
 
 The API schemes and host URLs are as follows:
 
-* `http://node:8091/`
-* `https://node:18091/` (for secure access)
+* http://node:8091/
+* https://node:18091/ (for secure access)
 
 where `node` is the host name or IP address of a node running the Query service.
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip

--- a/src/admin/admin.gradle
+++ b/src/admin/admin.gradle
@@ -9,7 +9,7 @@ convertSwagger2markup {
               'swagger2markup.tagOrderBy' : 'AS_IS',
               'swagger2markup.operationOrderBy' : 'AS_IS',
               'swagger2markup.definitionOrderBy' : 'AS_IS',
-              'swagger2markup.swaggerMarkupLanguage' : 'ASCIIDOC',
+              'swagger2markup.swaggerMarkupLanguage' : 'MARKDOWN',
               'swagger2markup.flatBodyEnabled' : false,
               'swagger2markup.extensions.springRestDocs.snippetBaseUri' : file('asciidoc/extensions/paths').absolutePath,
               'swagger2markup.extensions.springRestDocs.markupLanguage' : 'ASCIIDOC',

--- a/src/admin/asciidoc/extensions/paths/delete_active_request/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/delete_active_request/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-delete[Terminate an Active Request] for examples.

--- a/src/admin/asciidoc/extensions/paths/delete_completed_request/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/delete_completed_request/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-delete[Purge the Completed Requests] for examples.

--- a/src/admin/asciidoc/extensions/paths/delete_prepared/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/delete_prepared/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-delete[Delete Prepared Statements] for examples.

--- a/src/admin/asciidoc/extensions/paths/get_active_request/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/get_active_request/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Active Requests] for examples.

--- a/src/admin/asciidoc/extensions/paths/get_active_requests/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/get_active_requests/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Active Requests] for examples.

--- a/src/admin/asciidoc/extensions/paths/get_completed_request/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/get_completed_request/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Completed Requests] for examples.

--- a/src/admin/asciidoc/extensions/paths/get_completed_requests/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/get_completed_requests/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Completed Requests] for examples.

--- a/src/admin/asciidoc/extensions/paths/get_prepared/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/get_prepared/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Prepared Statements] for examples.

--- a/src/admin/asciidoc/extensions/paths/get_prepareds/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/get_prepareds/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Prepared Statements] for examples.

--- a/src/admin/asciidoc/extensions/paths/get_settings/operation-description-after.adoc
+++ b/src/admin/asciidoc/extensions/paths/get_settings/operation-description-after.adoc
@@ -1,0 +1,1 @@
+NOTE: Refer to xref:settings:query-settings.adoc[] for more information.

--- a/src/admin/asciidoc/extensions/paths/get_vitals/http-request.adoc
+++ b/src/admin/asciidoc/extensions/paths/get_vitals/http-request.adoc
@@ -1,0 +1,1 @@
+Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#vitals[Get System Vitals] for examples.

--- a/src/admin/asciidoc/extensions/paths/post_settings/operation-description-after.adoc
+++ b/src/admin/asciidoc/extensions/paths/post_settings/operation-description-after.adoc
@@ -1,0 +1,1 @@
+NOTE: Refer to xref:settings:query-settings.adoc[] for more information.

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1791,6 +1791,40 @@ definitions:
         x-desc-refs: |
           [queryUseCBO]: ../../rest-api/rest-cluster-query-settings.html#queryUseCBO
           [use_cbo_req]: index.html#use_cbo_req
+      use-replica:
+        type: string
+        default: unset
+        enum: ["off","on","unset"]
+        example: on
+        x-desc-name: use-replica-srv
+        description: |
+          [#use-replica-srv]
+          Specifies whether a query can fetch data from a replica vBucket if active vBuckets are inaccessible.
+          The possible values are:
+
+          * `off` &mdash; read from replica is disabled for all queries and cannot be overridden at request level.
+
+          * `on` &mdash; read from replica is enabled for all queries, but can be disabled at request level.
+
+          * `unset` &mdash; read from replica is enabled or disabled at request level.
+
+          The [cluster-level][queryUseReplica] `queryUseReplica` setting specifies the default for this property for the whole cluster.
+          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+          In addition, the [request-level][use_replica_req] `use_replica` parameter specifies this property per request.
+          If a request does not include this parameter, or if the request-level parameter is `unset`, the node-level setting is used.
+          If the request-level parameter and the node-level setting are both `unset`, read from replica is disabled for that request.
+
+          WARNING: Do not enable read from replica when you require consistent results.
+
+          SELECT queries within a transaction cannot read from replica.
+
+          [queryUseReplica]: #queryUseReplica
+          [use_replica_req]: #use_replica_req
+        x-desc-refs: |
+          [queryUseReplica]: ../../rest-api/rest-cluster-query-settings.html#queryUseReplica
+          [use_replica_req]: index.html#use_replica_req
+
 parameters:
   PathStat:
     name: stat

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -465,8 +465,6 @@ paths:
       summary: Retrieve Node-Level Query Settings
       description: |
         Returns node-level query settings.
-
-        NOTE: Refer to [Query Settings](../../settings/query-settings.html) for more information.
       tags:
         - settings
       security:
@@ -481,8 +479,6 @@ paths:
       summary: Update Node-Level Query Settings
       description: |
         Updates node-level query settings.
-
-        NOTE: Refer to [Query Settings](../../settings/query-settings.html) for more information.
       tags:
         - settings
       security:

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1771,9 +1771,13 @@ definitions:
           If a request does not include this parameter, or if the request-level parameter is `unset`, the node-level setting is used.
           If the request-level parameter and the node-level setting are both `unset`, read from replica is disabled for that request.
 
-          WARNING: Do not enable read from replica when you require consistent results.
+          Do not enable read from replica when you require consistent results.
+          Only SELECT queries that are not within a transaction can read from replica.
 
-          SELECT queries within a transaction cannot read from replica.
+          Reading from replica is only possible if the cluster uses Couchbase Server 7.6.0 or later.
+
+          Note that KV range scans cannot currently be started on a replica vBucket.
+          If a query uses sequential scan and a data node becomes unavailable, the query might return an error, even if read from replica is enabled for the request.
 
           [queryUseReplica]: #queryUseReplica
           [use_replica_req]: #use_replica_req

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -138,10 +138,6 @@ paths:
       summary: Retrieve All Prepared Statements
       description: |
         Returns all prepared statements.
-
-        NOTE: Refer to [Get Prepared Statements][sys-prepared-get] for examples.
-
-        [sys-prepared-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-get
       tags:
         - prepared statements
       security:
@@ -162,10 +158,6 @@ paths:
         - $ref: "#/parameters/PathName"
       description: |
         Returns the specified prepared statement.
-
-        NOTE: Refer to [Get Prepared Statements][sys-prepared-get] for examples.
-
-        [sys-prepared-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-get
       tags:
         - prepared statements
       security:
@@ -182,10 +174,6 @@ paths:
         - $ref: "#/parameters/PathName"
       description: |
         Deletes the specified prepared statement.
-
-        NOTE: Refer to [Delete Prepared Statements][sys-prepared-delete] for examples.
-
-        [sys-prepared-delete]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-delete
       tags:
         - prepared statements
       security:
@@ -206,10 +194,6 @@ paths:
       summary: Retrieve All Active Requests
       description: |
         Returns all active query requests.
-
-        NOTE: Refer to [Get Active Requests][sys-active-get] for examples.
-
-        [sys-active-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-get
       tags:
         - active requests
       security:
@@ -230,10 +214,6 @@ paths:
         - $ref: "#/parameters/PathRequest"
       description: |
         Returns the specified active query request.
-
-        NOTE: Refer to [Get Active Requests][sys-active-get] for examples.
-
-        [sys-active-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-get
       tags:
         - active requests
       security:
@@ -250,10 +230,6 @@ paths:
         - $ref: "#/parameters/PathRequest"
       description: |
         Terminates the specified active query request.
-
-        NOTE: Refer to [Terminate an Active Request][sys-active-delete] for examples.
-
-        [sys-active-delete]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-delete
       tags:
         - active requests
       security:
@@ -274,10 +250,6 @@ paths:
       summary: Retrieve All Completed Requests
       description: |
         Returns all completed requests.
-
-        NOTE: Refer to [Get Completed Requests][sys-completed-get] for examples.
-
-        [sys-completed-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-get
       tags:
         - completed requests
       security:
@@ -298,10 +270,6 @@ paths:
         - $ref: "#/parameters/PathRequest"
       description: |
         Returns the specified completed request.
-
-        NOTE: Refer to [Get Completed Requests][sys-completed-get] for examples.
-
-        [sys-completed-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-get
       tags:
         - completed requests
       security:
@@ -318,10 +286,6 @@ paths:
         - $ref: "#/parameters/PathRequest"
       description: |
         Purges the specified completed request.
-
-        NOTE: Refer to [Purge the Completed Requests][sys-completed-delete] for examples.
-
-        [sys-completed-delete]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-delete
       tags:
         - completed requests
       security:
@@ -430,10 +394,6 @@ paths:
       description: |
         Returns data about the running state and health of the query engine.
         This information can be very useful to assess the current workload and performance characteristics of a query engine, and hence load-balance the requests being sent to various query engines.
-
-        NOTE: Refer to [Get System Vitals][vitals] for examples.
-
-        [vitals]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#vitals
       tags:
         - statistics
       security:

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -6,12 +6,12 @@ info:
     The Admin REST API is a secondary API provided by the Query service.
     This API enables you to retrieve statistics about the clusters and nodes running the Query service; view or specify node-level settings; and view or delete requests.
 
-    The API schemes and host URLs are as follows:{blank}
+    The API schemes and host URLs are as follows:
 
-    * `+http://node:8093/+`
-    * `+https://node:18093/+` (for secure access)
+    * http://node:8093/
+    * https://node:18093/ (for secure access)
 
-    where [.var]`node` is the host name or IP address of a computer running the Query service.
+    where `node` is the host name or IP address of a computer running the Query service.
 
 produces:
   - application/json
@@ -35,6 +35,15 @@ tags:
     description: Operations for query settings.
   - name: default
     description: Other operations.
+
+# The output of this spec is used in more than one location, so Markdown cannot use relative links.
+# Absolute links begin with /server/7.6 -- this must be replaced for every branch.
+# Relative links are currently expected to point to a location in the same page.
+# The x-desc-refs attribute records links which point to other REST API references, for future use.
+# The x-desc-name attribute records the ID of the parameter description, also for future use.
+
+# The swagger2markup Markdown converter does not recognize HTML tags like <a id="foo">.
+# For the moment we have to use the AsciiDoc markup [#foo], which is passed through unchanged.
 
 paths:
   /admin/clusters:
@@ -129,10 +138,10 @@ paths:
       summary: Retrieve All Prepared Statements
       description: |
         Returns all prepared statements.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Prepared Statements] for examples.
-        ====
+
+        NOTE: Refer to [Get Prepared Statements][sys-prepared-get] for examples.
+
+        [sys-prepared-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-get
       tags:
         - prepared statements
       security:
@@ -153,10 +162,10 @@ paths:
         - $ref: "#/parameters/PathName"
       description: |
         Returns the specified prepared statement.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-get[Get Prepared Statements] for examples.
-        ====
+
+        NOTE: Refer to [Get Prepared Statements][sys-prepared-get] for examples.
+
+        [sys-prepared-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-get
       tags:
         - prepared statements
       security:
@@ -173,10 +182,10 @@ paths:
         - $ref: "#/parameters/PathName"
       description: |
         Deletes the specified prepared statement.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-prepared-delete[Delete Prepared Statements] for examples.
-        ====
+
+        NOTE: Refer to [Delete Prepared Statements][sys-prepared-delete] for examples.
+
+        [sys-prepared-delete]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-prepared-delete
       tags:
         - prepared statements
       security:
@@ -197,10 +206,10 @@ paths:
       summary: Retrieve All Active Requests
       description: |
         Returns all active query requests.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Active Requests] for examples.
-        ====
+
+        NOTE: Refer to [Get Active Requests][sys-active-get] for examples.
+
+        [sys-active-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-get
       tags:
         - active requests
       security:
@@ -221,10 +230,10 @@ paths:
         - $ref: "#/parameters/PathRequest"
       description: |
         Returns the specified active query request.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-get[Get Active Requests] for examples.
-        ====
+
+        NOTE: Refer to [Get Active Requests][sys-active-get] for examples.
+
+        [sys-active-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-get
       tags:
         - active requests
       security:
@@ -241,10 +250,10 @@ paths:
         - $ref: "#/parameters/PathRequest"
       description: |
         Terminates the specified active query request.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-active-delete[Terminate an Active Request] for examples.
-        ====
+
+        NOTE: Refer to [Terminate an Active Request][sys-active-delete] for examples.
+
+        [sys-active-delete]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-active-delete
       tags:
         - active requests
       security:
@@ -265,10 +274,10 @@ paths:
       summary: Retrieve All Completed Requests
       description: |
         Returns all completed requests.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Completed Requests] for examples.
-        ====
+
+        NOTE: Refer to [Get Completed Requests][sys-completed-get] for examples.
+
+        [sys-completed-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-get
       tags:
         - completed requests
       security:
@@ -289,10 +298,10 @@ paths:
         - $ref: "#/parameters/PathRequest"
       description: |
         Returns the specified completed request.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-get[Get Completed Requests] for examples.
-        ====
+
+        NOTE: Refer to [Get Completed Requests][sys-completed-get] for examples.
+
+        [sys-completed-get]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-get
       tags:
         - completed requests
       security:
@@ -309,10 +318,10 @@ paths:
         - $ref: "#/parameters/PathRequest"
       description: |
         Purges the specified completed request.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-delete[Purge the Completed Requests] for examples.
-        ====
+
+        NOTE: Refer to [Purge the Completed Requests][sys-completed-delete] for examples.
+
+        [sys-completed-delete]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-delete
       tags:
         - completed requests
       security:
@@ -333,11 +342,9 @@ paths:
       summary: Retrieve Prepared Index Statements
       description: |
         Returns all prepared index statements.
-        [TIP]
-        ====
-        * Use <<_get_prepared>> to get information about a prepared index statement.
-        * Use <<_delete_prepared>> to delete a prepared index statement.
-        ====
+
+        * Use [Retrieve a Prepared Statement](#_get_prepared) to get information about a prepared index statement.
+        * Use [Delete a Prepared Statement](#_delete_prepared) to delete a prepared index statement.
       tags:
         - prepared statements
       security:
@@ -359,11 +366,9 @@ paths:
       summary: Retrieve Active Index Requests
       description: |
         Returns all active index requests.
-        [TIP]
-        ====
-        * Use <<_get_active_request>> to get information about an active index request.
-        * Use <<_delete_active_request>> to terminate an active index request.
-        ====
+
+        * Use [Retrieve an Active Request](#_get_active_request) to get information about an active index request.
+        * Use [Delete an Active Request](#_delete_active_request) to terminate an active index request.
       tags:
         - active requests
       security:
@@ -383,11 +388,9 @@ paths:
       summary: Retrieve Completed Index Requests
       description: |
         Returns all completed index requests.
-        [TIP]
-        ====
-        * Use <<_get_completed_request>> to get information about a completed index request.
-        * Use <<_delete_completed_request>> to purge a completed index request.
-        ====
+
+        * Use [Retrieve a Completed Request](#_get_completed_request) to get information about a completed index request.
+        * Use [Delete a Completed Request](#_delete_completed_request) to purge a completed index request.
       tags:
         - completed requests
       security:
@@ -427,10 +430,10 @@ paths:
       description: |
         Returns data about the running state and health of the query engine.
         This information can be very useful to assess the current workload and performance characteristics of a query engine, and hence load-balance the requests being sent to various query engines.
-        [NOTE]
-        ====
-        Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#vitals[Get System Vitals] for examples.
-        ====
+
+        NOTE: Refer to [Get System Vitals][vitals] for examples.
+
+        [vitals]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#vitals
       tags:
         - statistics
       security:
@@ -491,9 +494,10 @@ paths:
         - text/html
       responses:
         302:
-          description: Redirects to the <<_get_stats>> endpoint.
+          description: Redirects to the [Retrieve All Statistics](#_get_stats) endpoint.
           schema:
-            type: text/html
+            type: string
+            format: text/html
 
   /admin/settings:
     get:
@@ -501,10 +505,8 @@ paths:
       summary: Retrieve Node-Level Query Settings
       description: |
         Returns node-level query settings.
-        [NOTE]
-        ====
-        Refer to xref:settings:query-settings.adoc[Query Settings] for more information.
-        ====
+
+        NOTE: Refer to [Query Settings](../../settings/query-settings.html) for more information.
       tags:
         - settings
       security:
@@ -519,10 +521,8 @@ paths:
       summary: Update Node-Level Query Settings
       description: |
         Updates node-level query settings.
-        [NOTE]
-        ====
-        Refer to xref:settings:query-settings.adoc[Query Settings] for more information.
-        ====
+
+        NOTE: Refer to [Query Settings](../../settings/query-settings.html) for more information.
       tags:
         - settings
       security:
@@ -592,7 +592,11 @@ definitions:
         type: string
         description: |
           The opaque ID or context provided by the client.
-          Refer to the {client_context_id}[request-level] `client_context_id` parameter for more information.
+          Refer to the [request-level][client_context_id] `client_context_id` parameter for more information.
+
+          [client_context_id]: #client_context_id
+        x-desc-refs: |
+          [client_context_id]: index.html#client_context_id
       elapsedTime:
         type: string
         format: duration
@@ -614,17 +618,23 @@ definitions:
         type: object
         description: |
           Count of documents processed at selective phases involved in the query execution.
-          Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#profile[Attribute Profile in Query Response] for more details and examples.
+          Refer to [Attribute Profile in Query Response][profile] for more details and examples.
+
+          [profile]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#profile
       phaseOperators:
         type: object
         description: |
           Indicates the number of each kind of query operators involved in different phases of the query processing.
-          Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#profile[Attribute Profile in Query Response] for more details and examples.
+          Refer to [Attribute Profile in Query Response][profile] for more details and examples.
+
+          [profile]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#profile
       phaseTimes:
         type: object
         description: |
           Cumulative execution times for various phases involved in the query execution.
-          Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#profile[Attribute Profile in Query Response] for more details and examples.
+          Refer to [Attribute Profile in Query Response][profile] for more details and examples.
+
+          [profile]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#profile
       remoteAddr:
         type: string
         description: IP address and port number of the client application, from where the query is received.
@@ -1100,56 +1110,76 @@ definitions:
       atrcollection:
         type: string
         default: ""
-        example: pass:c[default:`travel-sample`.transaction.test]
+        example: default:&grave;travel-sample&grave;.transaction.test
+        x-desc-name: atrcollection-srv
         description: |
-          [[atrcollection-srv]]
-          Specifies the collection where xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] are stored.
+          [#atrcollection-srv]
+          Specifies the collection where [active transaction records][additional-storage-use] are stored.
           The collection must be present.
           If not specified, the active transaction record is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
 
           The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
-          If any part of the path contains a special character, that part of the path must be delimited in backticks `pass:c[``]`.
+          If any part of the path contains a special character, that part of the path must be delimited in backticks &grave;&grave;.
 
-          The {atrcollection_req}[request-level] `atrcollection` parameter specifies this property per request.
+          The [request-level][atrcollection_req] `atrcollection` parameter specifies this property per request.
           If a request does not include this parameter, the node-level `atrcollection` setting will be used.
+
+          [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
+          [atrcollection_req]: #atrcollection_req
+        x-desc-refs: |
+          [atrcollection_req]: index.html#atrcollection_req
       auto-prepare:
         type: boolean
         default: false
         example: true
+        x-desc-name: auto-prepare
         description: |
-          [[auto-prepare]]
-          Specifies whether the query engine should create a prepared statement every time a N1QL request is submitted, whether the PREPARE statement is included or not.
+          [#auto-prepare]
+          Specifies whether the query engine should create a prepared statement every time a SQL++ request is submitted, whether the PREPARE statement is included or not.
           
-          Refer to xref:n1ql:n1ql-language-reference/prepare.adoc#auto-prepare[Auto-Prepare] for more information.
+          Refer to [Auto-Prepare][auto-prepare] for more information.
+
+          [auto-prepare]: /server/7.6/n1ql/n1ql-language-reference/prepare.html#auto-prepare
 
       cleanupclientattempts:
         type: boolean
         default: true
         example: false
+        x-desc-name: cleanupclientattempts
         description: |
-          [[cleanupclientattempts]]
+          [#cleanupclientattempts]
           When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
 
-          The {queryCleanupClientAttempts}[cluster-level] `queryCleanupClientAttempts` setting specifies this property for the whole cluster.
+          The [cluster-level][queryCleanupClientAttempts] `queryCleanupClientAttempts` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [queryCleanupClientAttempts]: #queryCleanupClientAttempts
+        x-desc-refs: |
+          [queryCleanupClientAttempts]: ../../rest-api/rest-cluster-query-settings.html#queryCleanupClientAttempts
       cleanuplostattempts:
         type: boolean
         default: true
         example: false
+        x-desc-name: cleanuplostattempts
         description: |
-          [[cleanuplostattempts]]
+          [#cleanuplostattempts]
           When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
 
-          The {queryCleanupLostAttempts}[cluster-level] `queryCleanupLostAttempts` setting specifies this property for the whole cluster.
+          The [cluster-level][queryCleanupLostAttempts] `queryCleanupLostAttempts` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [queryCleanupLostAttempts]: #queryCleanupLostAttempts
+        x-desc-refs: |
+          [queryCleanupLostAttempts]: ../../rest-api/rest-cluster-query-settings.html#queryCleanupLostAttempts
       cleanupwindow:
         type: string
         format: duration
         default: 60s
         example: 30s
+        x-desc-name: cleanupwindow
         description: |
-          [[cleanupwindow]]
-          Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for cleanup.
+          [#cleanupwindow]
+          Specifies how frequently the Query service checks its subset of [active transaction records][additional-storage-use] for cleanup.
           Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
 
           The value for this setting is a string.
@@ -1163,19 +1193,27 @@ definitions:
           * `m` (minutes)
           * `h` (hours)
 
-          The {queryCleanupWindow}[cluster-level] `queryCleanupWindow` setting specifies this property for the whole cluster.
+          The [cluster-level][queryCleanupWindow] `queryCleanupWindow` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
+          [queryCleanupWindow]: #queryCleanupWindow
+        x-desc-refs: |
+          [queryCleanupWindow]: ../../rest-api/rest-cluster-query-settings.html#queryCleanupWindow
       completed:
         type: object
         title: Logging parameters
         default: {"aborted": null, "threshold": 1000}
         example: {"user": "marco", "error": 12003}
+        x-desc-name: completed
         description: |
-          [[completed]]
+          [#completed]
           A nested object that sets the parameters for the completed requests catalog.
           All completed requests that match these parameters are tracked in the completed requests catalog.
 
-          Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples.
+          Refer to [Configure the Completed Requests][sys-completed-config] for more information and examples.
+
+          [sys-completed-config]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config
         properties:
           aborted:
             type: boolean
@@ -1195,7 +1233,11 @@ definitions:
               The opaque ID or context provided by the client.
               If specified, all completed requests with this client context ID are logged.
               
-              Refer to the {client_context_id}[request-level] `client_context_id` parameter for more information.
+              Refer to the [request-level][client_context_id] `client_context_id` parameter for more information.
+
+              [client_context_id]: #client_context_id
+            x-desc-refs: |
+              [client_context_id]: index.html#client_context_id
           error:
             type: integer
             format: int32
@@ -1211,7 +1253,9 @@ definitions:
             description: |
               A unique string which tags a set of qualifiers.
 
-              Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information.
+              Refer to [Configure the Completed Requests][sys-completed-config] for more information.
+
+              [sys-completed-config]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config
           threshold:
             type: integer
             format: int32
@@ -1221,7 +1265,7 @@ definitions:
               A duration in milliseconds.
               If specified, all completed queries lasting longer than this threshold are logged.
 
-              This is another way of specifying the {completed-threshold-srv}[node-level] `completed-threshold` setting.
+              This is another way of specifying the [node-level](#completed-threshold) `completed-threshold` setting.
           user: 
             type: string
             default: ""
@@ -1234,79 +1278,95 @@ definitions:
         format: int32
         default: 4000
         example: 7000
+        x-desc-name: completed-limit
         description: |
-          [[completed-limit]]
+          [#completed-limit]
           Sets the number of requests to be logged in the completed requests catalog.
           As new completed requests are added, old ones are removed.
 
           Increase this when the completed request keyspace is not big enough to track the slow requests, such as when you want a larger sample of slow requests.
 
-          Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples.
+          Refer to [Configure the Completed Requests][sys-completed-config] for more information and examples.
 
-          The {queryCompletedLimit}[cluster-level] `queryCompletedLimit` setting specifies this property for the whole cluster.
+          The [cluster-level][queryCompletedLimit] `queryCompletedLimit` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [sys-completed-config]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config
+          [queryCompletedLimit]: #queryCompletedLimit
+        x-desc-refs: |
+          [queryCompletedLimit]: ../../rest-api/rest-cluster-query-settings.html#queryCompletedLimit
       completed-threshold:
         type: integer
         format: int32
         default: 1000
         example: 7000
+        x-desc-name: completed-threshold
         description: |
-          [[completed-threshold]]
+          [#completed-threshold]
           A duration in milliseconds.
           All completed queries lasting longer than this threshold are logged in the completed requests catalog.
 
           Specify `0` to track all requests, independent of duration.
           Specify any negative number to track none.
 
-          Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples.
+          Refer to [Configure the Completed Requests][sys-completed-config] for more information and examples.
 
-          The {queryCompletedThreshold}[cluster-level] `queryCompletedThreshold` setting specifies this property for the whole cluster.
+          The [cluster-level][queryCompletedThreshold] `queryCompletedThreshold` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [sys-completed-config]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config
+          [queryCompletedThreshold]: #queryCompletedThreshold
+        x-desc-refs: |
+          [queryCompletedThreshold]: ../../rest-api/rest-cluster-query-settings.html#queryCompletedThreshold
       controls:
         type: boolean
         default: false
         example: true
+        x-desc-name: controls-srv
         description: |
-          [[controls-srv]]
+          [#controls-srv]
           Specifies if there should be a controls section returned with the request results.
 
           When set to `true`, the query response document includes a controls section with runtime information provided along with the request, such as positional and named parameters or settings.
 
-          [NOTE]
-          If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
+          NOTE: If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
 
-          The {controls_req}[request-level] `controls` parameter specifies this property per request.
+          The [request-level][controls_req] `controls` parameter specifies this property per request.
           If a request does not include this parameter, the node-level `controls` setting will be used.
+
+          [controls_req]: #controls_req
+        x-desc-refs: |
+          [controls_req]: index.html#controls_req
       cpuprofile:
         type: string
         default: ""
         example: /tmp/info.txt
+        x-desc-name: cpuprofile
         description: |
-          [[cpuprofile]]
+          [#cpuprofile]
           The absolute path and filename to write the CPU profile to a local file.
 
           The output file includes a controls section and performance measurements, such as memory allocation and garbage collection, to pinpoint bottlenecks and ways to improve your code execution.
 
+          NOTE: If `cpuprofile` is left running too long, it can slow the system down as its file size increases.
+
           To stop `cpuprofile`, run with the empty setting of `""`.
-
-          [NOTE]
-          If `cpuprofile` is left running too long, it can slow the system down as its file size increases.
-
-          //
       debug:
         type: boolean
         default: false
         example: true
+        x-desc-name: debug
         description: |
-          [[debug]]
+          [#debug]
           Use debug mode.
 
           When set to `true`, extra logging is provided.
       distribute:
         type: boolean
         example: true
+        x-desc-name: distribute
         description: |
-          [[distribute]]
+          [#distribute]
           This field is only available with the POST method.
           When specified alongside other settings, this field instructs the node that is processing the request to cascade those settings to all other query nodes.
           The actual value of this field is ignored.
@@ -1315,55 +1375,63 @@ definitions:
         format: int32
         default: 16384
         example: 7000
+        x-desc-name: functions-limit
         description: |
-          [[functions-limit]]
+          [#functions-limit]
           Maximum number of user-defined functions.
       keep-alive-length:
         type: integer
         format: int32
         default: 16384
         example: 7000
+        x-desc-name: keep-alive-length
         description: |
-          [[keep-alive-length]]
+          [#keep-alive-length]
           Maximum size of buffered result.
       loglevel:
         type: string
         default: INFO
         enum: ["DEBUG","TRACE","INFO","WARN","ERROR","SEVERE","NONE"]
         example: DEBUG
+        x-desc-name: loglevel
         description: |
-          [[loglevel]]
+          [#loglevel]
           Log level used in the logger.
 
-          All values, in descending order of data:{blank}
+          All values, in descending order of data:
 
-          `DEBUG` -- For developers.
+          * `DEBUG` &mdash; For developers.
           Writes everything.
 
-          `TRACE` -- For developers.
+          * `TRACE` &mdash; For developers.
           Less info than `DEBUG`.
 
-          `INFO` -- For admin & customers.
+          * `INFO` &mdash; For admin & customers.
           Lists warnings & errors.
 
-          `WARN` -- For admin.
+          * `WARN` &mdash; For admin.
           Only abnormal items.
 
-          `ERROR` -- For admin.
+          * `ERROR` &mdash; For admin.
           Only errors to be fixed.
 
-          `SEVERE` -- For admin.
+          * `SEVERE` &mdash; For admin.
           Major items, like crashes.
 
-          `NONE` -- Doesn’t write anything.
+          * `NONE` &mdash; Doesn't write anything.
 
-          The {queryLogLevel}[cluster-level] `queryLogLevel` setting specifies this property for the whole cluster.
+          The [cluster-level][queryLogLevel] `queryLogLevel` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [queryLogLevel]: #queryLogLevel
+        x-desc-refs: |
+          [queryLogLevel]: ../../rest-api/rest-cluster-query-settings.html#queryLogLevel
       max-index-api:
         type: integer
         format: int32
+        x-desc-name: max-index-api
         description: |
-          [[max-index-api]]
+          [#max-index-api]
           Max index API.
           This setting is provided for technical support only.
       max-parallelism:
@@ -1371,8 +1439,9 @@ definitions:
         format: int32
         default: 1
         example: 0
+        x-desc-name: max-parallelism-srv
         description: |
-          [[max-parallelism-srv]]
+          [#max-parallelism-srv]
           Specifies the maximum parallelism for queries on this node.
 
           If the value is zero or negative, the maximum parallelism is restricted to the number of allowed cores.
@@ -1382,25 +1451,32 @@ definitions:
           In Community Edition, the number of allowed cores cannot be greater than 4.
           In Enterprise Edition, there is no limit to the number of allowed cores.)
 
-          The {queryMaxParallelism}[cluster-level] `queryMaxParallelism` setting specifies this property for the whole cluster.
+          The [cluster-level][queryMaxParallelism] `queryMaxParallelism` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, there is a {max_parallelism_req}[request-level] `max_parallelism` parameter.
+          In addition, there is a [request-level][max_parallelism_req] `max_parallelism` parameter.
           If a request includes this parameter, it will be capped by the node-level `max-parallelism` setting.
 
-          [NOTE]
-          To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
+          NOTE: To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
 
-          Refer to xref:n1ql:n1ql-language-reference/index-partitioning.adoc#max-parallelism[Max Parallelism] for more information.
+          Refer to [Max Parallelism][max-parallelism] for more information.
+
+          [max-parallelism]: /server/7.6/n1ql/n1ql-language-reference/index-partitioning.html#max-parallelism
+          [queryMaxParallelism]: #queryMaxParallelism
+          [max_parallelism_req]: #max_parallelism_req
+        x-desc-refs: |
+          [queryMaxParallelism]: ../../rest-api/rest-cluster-query-settings.html#queryMaxParallelism
+          [max_parallelism_req]: index.html#max_parallelism_req
       memory-quota:
         type: integer
         format: int32
         default: 0
         example: 4
+        x-desc-name: memory-quota-srv
         description: |
-          [[memory-quota-srv]]
+          [#memory-quota-srv]
           Specifies the maximum amount of memory a request may use on this node, in MB.
-          Note that the overall node memory quota is this setting multiplied by the <<servicers,node-level>> `servicers` setting.
+          Note that the overall node memory quota is this setting multiplied by the [node-level](#servicers) `servicers` setting.
 
           Specify `0` (the default value) to disable.
           When disabled, there is no quota.
@@ -1408,43 +1484,56 @@ definitions:
           Within a transaction, this setting enforces the memory quota for the transaction.
           The transaction memory quota tracks only the delta table and the transaction log (approximately).
 
-          The {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies this property for the whole cluster.
+          The [cluster-level][queryMemoryQuota] `queryMemoryQuota` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {memory_quota_req}[request-level] `memory_quota` parameter specifies this property per request.
+          In addition, the [request-level][memory_quota_req] `memory_quota` parameter specifies this property per request.
           If a request includes this parameter, it will be capped by the node-level `memory-quota` setting.
+
+          [queryMemoryQuota]: #queryMemoryQuota
+          [memory_quota_req]: #memory_quota_req
+        x-desc-refs: |
+          [queryMemoryQuota]: ../../rest-api/rest-cluster-query-settings.html#queryMemoryQuota
+          [memory_quota_req]: index.html#memory_quota_req
       memprofile:
         type: string
         default: ""
         example: /tmp/memory-usage.log
+        x-desc-name: memprofile
         description: |
-          [[memprofile]]
+          [#memprofile]
           Filename to write the diagnostic memory usage log.
 
+          NOTE: If `memprofile` is left running too long, it can slow the system down as its file size increases.
+
           To stop `memprofile`, run with the empty setting of `""`.
-
-          [NOTE]
-          If `memprofile` is left running too long, it can slow the system down as its file size increases.
-
-          //
       mutexprofile:
         type: boolean
         default: false
+        x-desc-name: mutexprofile
         description: |
-          [[mutexprofile]]
+          [#mutexprofile]
           Mutex profile.
           This setting is provided for technical support only.
       numatrs:
         type: string
+        x-desc-name: numatrs-srv
         description: |
-          [[numatrs-srv]]
-          Specifies the total number of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records].
+          [#numatrs-srv]
+          Specifies the total number of [active transaction records][additional-storage-use].
 
-          The {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies this property for the whole cluster.
+          The [cluster-level][queryNumAtrs] `queryNumAtrs` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {numatrs_req}[request-level] `numatrs` parameter specifies this property per request.
+          In addition, the [request-level][numatrs_req] `numatrs` parameter specifies this property per request.
           The minimum of that and the node-level `numatrs` setting is applied.
+
+          [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
+          [queryNumAtrs]: #queryNumAtrs
+          [numatrs_req]: #numatrs_req
+        x-desc-refs: |
+          [queryNumAtrs]: ../../rest-api/rest-cluster-query-settings.html#queryNumAtrs
+          [numatrs_req]: index.html#numatrs_req
       n1ql-feat-ctrl:
         type: integer
         # type should be [string, integer] but swagger2markup cannot process
@@ -1452,48 +1541,68 @@ definitions:
         format: int32
         default: 76
         example: "0x1"
+        x-desc-name: n1ql-feat-ctrl
         description: |
-          [[n1ql-feat-ctrl]]
-          {sqlpp} feature control.
+          [#n1ql-feat-ctrl]
+          SQL++ feature control.
           This setting is provided for technical support only.
           The value may be an integer, or a string representing a hexadecimal number.
 
-          The {queryN1qlFeatCtrl}[cluster-level] `queryN1qlFeatCtrl` setting specifies this property for the whole cluster.
+          The [cluster-level][queryN1qlFeatCtrl] `queryN1qlFeatCtrl` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [queryN1qlFeatCtrl]: #queryN1qlFeatCtrl
+        x-desc-refs: |
+          [queryN1qlFeatCtrl]: ../../rest-api/rest-cluster-query-settings.html#queryN1qlFeatCtrl
       pipeline-batch:
         type: integer
         format: int32
         default: 16
         example: 64
+        x-desc-name: pipeline-batch-srv
         description: |
-          [[pipeline-batch-srv]]
+          [#pipeline-batch-srv]
           Controls the number of items execution operators can batch for Fetch from the KV.
 
-          The {queryPipelineBatch}[cluster-level] `queryPipelineBatch` setting specifies this property for the whole cluster.
+          The [cluster-level][queryPipelineBatch] `queryPipelineBatch` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {pipeline_batch_req}[request-level] `pipeline_batch` parameter specifies this property per request.
+          In addition, the [request-level][pipeline_batch_req] `pipeline_batch` parameter specifies this property per request.
           The minimum of that and the node-level `pipeline-batch` setting is applied.
+
+          [queryPipelineBatch]: #queryPipelineBatch
+          [pipeline_batch_req]: #pipeline_batch_req
+        x-desc-refs: |
+          [queryPipelineBatch]: ../../rest-api/rest-cluster-query-settings.html#queryPipelineBatch
+          [pipeline_batch_req]: index.html#pipeline_batch_req
       pipeline-cap:
         type: integer
         format: int32
         default: 512
         example: 1024
+        x-desc-name: pipeline-cap-srv
         description: |
-          [[pipeline-cap-srv]]
+          [#pipeline-cap-srv]
           Maximum number of items each execution operator can buffer between various operators.
 
-          The {queryPipelineCap}[cluster-level] `queryPipelineCap` setting specifies this property for the whole cluster.
+          The [cluster-level][queryPipelineCap] `queryPipelineCap` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {pipeline_cap_req}[request-level] `pipeline_cap` parameter specifies this property per request.
+          In addition, the [request-level][pipeline_cap_req] `pipeline_cap` parameter specifies this property per request.
           The minimum of that and the node-level `pipeline-cap` setting is applied.
+
+          [queryPipelineCap]: #queryPipelineCap
+          [pipeline_cap_req]: #pipeline_cap_req
+        x-desc-refs: |
+          [queryPipelineCap]: ../../rest-api/rest-cluster-query-settings.html#queryPipelineCap
+          [pipeline_cap_req]: index.html#pipeline_cap_req
       plus-servicers:
         type: integer
         format: int32
         example: 16
+        x-desc-name: plus-servicers
         description: |
-          [[plus-servicers]]
+          [#plus-servicers]
           The number of service threads for transactions where the scan consistency is `request_plus` or `at_plus`.
           The default is 16 times the number of logical cores.
       prepared-limit:
@@ -1501,92 +1610,117 @@ definitions:
         format: int32
         default: 16384
         example: 65536
+        x-desc-name: prepared-limit
         description: |
-          [[prepared-limit]]
+          [#prepared-limit]
           Maximum number of prepared statements in the cache.
           When this cache reaches the limit, the least recently used prepared statements will be discarded as new prepared statements are created.
 
-          The {queryPreparedLimit}[cluster-level] `queryPreparedLimit` setting specifies this property for the whole cluster.
+          The [cluster-level][queryPreparedLimit] `queryPreparedLimit` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [queryPreparedLimit]: #queryPreparedLimit
+        x-desc-refs: |
+          [queryPreparedLimit]: ../../rest-api/rest-cluster-query-settings.html#queryPreparedLimit
       pretty:
         type: boolean
         default: false
         example: true
+        x-desc-name: pretty-srv
         description: |
-          [[pretty-srv]]
+          [#pretty-srv]
           Specifies whether query results are returned in pretty format.
 
-          The {pretty_req}[request-level] `pretty` parameter specifies this property per request.
+          The [request-level][pretty_req] `pretty` parameter specifies this property per request.
           If a request does not include this parameter, the node-level setting is used, which defaults to `false`.
+
+          [pretty_req]: #pretty_req
+        x-desc-refs: |
+          [pretty_req]: index.html#pretty_req
       profile:
         type: string
         default: "off"
         example: "phases"
         enum: ["off","phases","timings"]
+        x-desc-name: profile-srv
         description: |
-          [[profile-srv]]
+          [#profile-srv]
           Specifies if there should be a profile section returned with the request results.
-          The valid values are:{blank}
+          The valid values are:
 
-          `off` -- No profiling information is added to the query response.
+          * `off` &mdash; No profiling information is added to the query response.
 
-          `phases` -- The query response includes a profile section with stats and details about various phases of the query plan and execution.
+          * `phases` &mdash; The query response includes a profile section with stats and details about various phases of the query plan and execution.
           Three phase times will be included in the `system:active_requests` and `system:completed_requests` monitoring keyspaces.
 
-          `timings` -- Besides the phase times, the profile section of the query response document will include a full query plan with timing and information about the number of processed documents at each phase.
+          * `timings` &mdash; Besides the phase times, the profile section of the query response document will include a full query plan with timing and information about the number of processed documents at each phase.
           This information will be included in the `system:active_requests` and `system:completed_requests` keyspaces.
 
-          [NOTE]
-          If `profile` is not set as one of the above values, then the profile setting does not change.
+          NOTE: If `profile` is not set as one of the above values, then the profile setting does not change.
           
-          Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#monitor-profile-details[Monitoring and Profiling Details] for more information and examples.
+          Refer to [Monitoring and Profiling Details][monitor-profile-details] for more information and examples.
 
-          The {profile_req}[request-level] `profile` parameter specifies this property per request.
+          The [request-level][profile_req] `profile` parameter specifies this property per request.
           If a request does not include this parameter, the node-level `profile` setting will be used.
+
+          [monitor-profile-details]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#monitor-profile-details
+          [profile_req]: #profile_req
+        x-desc-refs: |
+          [profile_req]: index.html#profile_req
       request-size-cap:
         type: integer
         format: int32
         default: 67108864
         example: 70000
+        x-desc-name: request-size-cap
         description: |
-          [[request-size-cap]]
+          [#request-size-cap]
           Maximum size of a request.
       scan-cap:
         type: integer
         format: int32
         default: 512
         example: 1024
+        x-desc-name: scan-cap-srv
         description: |
-          [[scan-cap-srv]]
+          [#scan-cap-srv]
           Maximum buffered channel size between the indexer client and the query service for index scans.
           This parameter controls when to use scan backfill.
 
           Use `0` or a negative number to disable.
           Smaller values reduce GC, while larger values reduce indexer backfill.
 
-          The {queryScanCap}[cluster-level] `queryScanCap` setting specifies this property for the whole cluster.
+          The [cluster-level][queryScanCap] `queryScanCap` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {scan_cap_req}[request-level] `scan_cap` parameter specifies this property per request.
+          In addition, the [request-level][scan_cap_req] `scan_cap` parameter specifies this property per request.
           The minimum of that and the node-level `scan-cap` setting is applied.
+
+          [queryScanCap]: #queryScanCap
+          [scan_cap_req]: #scan_cap_req
+        x-desc-refs: |
+          [queryScanCap]: ../../rest-api/rest-cluster-query-settings.html#queryScanCap
+          [scan_cap_req]: index.html#scan_cap_req
       servicers:
         type: integer
         format: int32
         default: 32
         example: 8
+        x-desc-name: servicers
         description: |
-          [[servicers]]
+          [#servicers]
           The number of service threads for the query.
           The default is 4 times the number of cores on the query node.
 
-          Note that the overall node memory quota is this setting multiplied by the <<memory-quota-srv,node-level>> `memory-quota` setting.
+          Note that the overall node memory quota is this setting multiplied by the [node-level](#memory-quota-srv) `memory-quota` setting.
       timeout:
         type: integer
         format: int64
         default: 0
         example: 500000000
+        x-desc-name: timeout-srv
         description: |
-          [[timeout-srv]]
+          [#timeout-srv]
           Maximum time to spend on the request before timing out (ns).
 
           The value for this setting is an integer, representing a duration in nanoseconds.
@@ -1595,20 +1729,27 @@ definitions:
           Specify `0` (the default value) or a negative integer to disable.
           When disabled, no timeout is applied and the request runs for however long it takes.
 
-          The {queryTimeout}[cluster-level] `queryTimeout` setting specifies this property for the whole cluster.
+          The [cluster-level][queryTimeout] `queryTimeout` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {timeout_req}[request-level] `timeout` parameter specifies this property per request.
+          In addition, the [request-level][timeout_req] `timeout` parameter specifies this property per request.
           The minimum of that and the node-level `timeout` setting is applied.
+
+          [queryTimeout]: #queryTimeout
+          [timeout_req]: #timeout_req
+        x-desc-refs: |
+          [queryTimeout]: ../../rest-api/rest-cluster-query-settings.html#queryTimeout
+          [timeout_req]: index.html#timeout_req
       txtimeout:
         type: integer
         format: int64
         default: 0
         example: 500000000
+        x-desc-name: txtimeout-srv
         description: |
-          [[txtimeout-srv]]
+          [#txtimeout-srv]
           Maximum time to spend on a transaction before timing out (ns).
-          This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
+          This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the [tximplicit][tximplicit] parameter is set.
           For all other requests, it is ignored.
 
           The value for this setting is an integer, representing a duration in nanoseconds.
@@ -1617,25 +1758,39 @@ definitions:
           Specify `0` (the default value) to disable.
           When disabled, no timeout is applied and the transaction runs for however long it takes.
 
-          The {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies this property for the whole cluster.
+          The [cluster-level][queryTxTimeout] `queryTxTimeout` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {txtimeout_req}[request-level] `txtimeout` parameter specifies this property per request.
+          In addition, the [request-level][txtimeout_req] `txtimeout` parameter specifies this property per request.
           The minimum of that and the node-level `txtimeout` setting is applied.
+
+          [tximplicit]: #tximplicit
+          [queryTxTimeout]: #queryTxTimeout
+          [txtimeout_req]: #txtimeout_req
+        x-desc-refs: |
+          [tximplicit]: index.html#tximplicit
+          [queryTxTimeout]: ../../rest-api/rest-cluster-query-settings.html#queryTxTimeout
+          [txtimeout_req]: index.html#txtimeout_req
       use-cbo:
         type: boolean
         default: true
         example: false
+        x-desc-name: use-cbo-srv
         description: |
-          [[use-cbo-srv]]
+          [#use-cbo-srv]
           Specifies whether the cost-based optimizer is enabled.
 
-          The {queryUseCBO}[cluster-level] `queryUseCBO` setting specifies this property for the whole cluster.
+          The [cluster-level][queryUseCBO] `queryUseCBO` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
+          In addition, the [request-level][use_cbo_req] `use_cbo` parameter specifies this property per request.
           If a request does not include this parameter, the node-level setting is used, which defaults to `true`.
 
+          [queryUseCBO]: #queryUseCBO
+          [use_cbo_req]: #use_cbo_req
+        x-desc-refs: |
+          [queryUseCBO]: ../../rest-api/rest-cluster-query-settings.html#queryUseCBO
+          [use_cbo_req]: index.html#use_cbo_req
 parameters:
   PathStat:
     name: stat
@@ -1720,4 +1875,4 @@ securityDefinitions:
 
   None:
     type: basic
-    description: No authentication is required for the <<_get_ping>> or <<_get_debug_vars>> endpoints.
+    description: No authentication is required for the [Ping](#_get_ping) or [Get Debug Variables](#_get_debug_vars) endpoints.

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1,9 +1,9 @@
 swagger: '2.0'
 info:
-  title: Admin REST API
+  title: Query Admin REST API
   version: '7.6'
   description: |
-    The Admin REST API is a secondary API provided by the Query service.
+    The Query Admin REST API is a secondary API provided by the Query service.
     This API enables you to retrieve statistics about the clusters and nodes running the Query service; view or specify node-level settings; and view or delete requests.
 
     The API schemes and host URLs are as follows:

--- a/src/query-service/extensions/spring/get_service/http-request.adoc
+++ b/src/query-service/extensions/spring/get_service/http-request.adoc
@@ -10,4 +10,4 @@ curl -v http://localhost:8093/query/service?statement=SELECT%20name%20FROM%20%60
 ----
 ====
 
-For further examples, refer to {section_srh_tlm_n1b}[].
+For further examples, refer to xref:n1ql:n1ql-rest-api/examplesrest.adoc[].

--- a/src/query-service/extensions/spring/post_service/http-request.adoc
+++ b/src/query-service/extensions/spring/post_service/http-request.adoc
@@ -29,4 +29,4 @@ curl http://localhost:8093/query/service \
 Conversely, because it is sent as a JSON object, the statement in this example can contain a semicolon.
 ====
 
-For further examples, refer to {section_srh_tlm_n1b}[].
+For further examples, refer to xref:n1ql:n1ql-rest-api/examplesrest.adoc[].

--- a/src/query-service/query-service.gradle
+++ b/src/query-service/query-service.gradle
@@ -10,7 +10,7 @@ convertSwagger2markup {
               'swagger2markup.definitionOrderBy' : 'AS_IS',
               'swagger2markup.parameterOrderBy' : 'AS_IS',
               'swagger2markup.propertyOrderBy' : 'AS_IS',
-              'swagger2markup.swaggerMarkupLanguage' : 'ASCIIDOC',
+              'swagger2markup.swaggerMarkupLanguage' : 'MARKDOWN',
               'swagger2markup.flatBodyEnabled' : false,
               'swagger2markup.extensions.springRestDocs.snippetBaseUri' : file('extensions/spring').absolutePath,
               'swagger2markup.extensions.springRestDocs.markupLanguage' : 'ASCIIDOC',

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -185,11 +185,10 @@ definitions:
         x-desc-name: args
         description: |
           [#args]
-          Applicable if the statement has 1 or more positional parameters.
-          
-          An array of JSON values, one for each positional parameter in the statement.
+          Supplies the values for positional parameters in the statement.
+          Applicable if the statement or prepared statement contains 1 or more positional parameters.
 
-          Note that positional parameters apply to `prepared` also.
+          The value is an array of JSON values, one for each positional parameter in the statement.
 
           Refer to [Named Parameters and Positional Parameters][section_srh_tlm_n1b] for details.
 
@@ -963,16 +962,16 @@ definitions:
         x-desc-name: identifier
         description: |
           [#identifier]
-          Applicable if the `statement` has 1 or more named parameters.
+          Supplies the value for a named parameter in the statement.
+          Applicable if the statement or prepared statement contains 1 or more named parameters.
 
           The name of a named parameter consists of two parts:
 
           1. The `$` character.
-          2. An identifier that starts with an alpha character followed by one or more alphanumeric characters.
+          2. An identifier that specifies the name of the parameter.
+             This must start with an alpha character, followed by one or more alphanumeric characters.
 
-          The value of the named parameter is any JSON value.
-
-          Named parameters apply to `prepared` also.
+          The value of the named parameter can be any JSON value.
 
           Refer to [Named Parameters and Positional Parameters][section_srh_tlm_n1b] for details.
 

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -4,12 +4,12 @@ info:
   version: '7.6'
   description: |
     The Query Service REST API is provided by the Query service.
-    This API enables you to run {sqlpp} queries and set request-level parameters.
+    This API enables you to run SQL++ queries and set request-level parameters.
 
     The API schemes and host URLs are as follows:
 
-    * `http://node:8093/`
-    * `https://node:18093/` (for secure access)
+    * http://node:8093/
+    * https://node:18093/ (for secure access)
 
     where `node` is the host name or IP address of a node running the Query service.
 
@@ -26,7 +26,7 @@ paths:
       operationId: post_service
       summary: Query Service
       description: >
-        Enables you to execute a {sqlpp} statement.
+        Enables you to execute a SQL++ statement.
         This method allows you to run queries and modifying statements, and specify query parameters.
       parameters:
         - in: body
@@ -65,7 +65,7 @@ paths:
       operationId: get_service
       summary: Read-Only Query Service
       description: >
-        Enables you to execute a {sqlpp} statement.
+        Enables you to execute a SQL++ statement.
         This method allows you to run queries and modifying statements, and specify query parameters.
         It does not allow you to run modifying statements.
 
@@ -98,7 +98,14 @@ paths:
         "503":
           $ref: '#/responses/ServiceUnavailable'
 
-# Use attributes for xrefs so that they can point to different locations in different contexts
+# The output of this spec is used in more than one location, so Markdown cannot use relative links.
+# Absolute links begin with /server/7.6 -- this must be replaced for every branch.
+# Relative links are currently expected to point to a location in the same page.
+# The x-desc-refs attribute records links which point to other REST API references, for future use.
+# The x-desc-name attribute records the ID of the parameter description, also for future use.
+
+# The swagger2markup Markdown converter does not recognize HTML tags like <a id="foo">.
+# For the moment we have to use the AsciiDoc markup [#foo], which is passed through unchanged.
 
 responses:
   OK:
@@ -112,7 +119,7 @@ responses:
       The request cannot be processed for one of the following reasons:
 
 
-        * The statement contains a {sqlpp} syntax error.
+        * The statement contains a SQL++ syntax error.
 
 
         * The request has a missing or unrecognized HTTP parameter.
@@ -175,71 +182,69 @@ definitions:
       args:
         type: array
         items: {}
+        x-desc-name: args
         description: |
-          [[args]]
+          [#args]
           Applicable if the statement has 1 or more positional parameters.
           
           An array of JSON values, one for each positional parameter in the statement.
 
           Note that positional parameters apply to `prepared` also.
 
-          Refer to {section_srh_tlm_n1b}[] for details.
+          Refer to [Named Parameters and Positional Parameters][section_srh_tlm_n1b] for details.
+
+          [section_srh_tlm_n1b]: /server/7.6/settings/query-settings.html#section_srh_tlm_n1b
         example:
           - LAX
           - 6
       atrcollection:
         type: string
+        x-desc-name: atrcollection_req
         description: |
-          [[atrcollection_req]]
-          Specifies the collection where the {transactions-understanding-transactions}[active transaction record] (ATR) is stored.
+          [#atrcollection_req]
+          Specifies the collection where the [active transaction record][additional-storage-use] (ATR) is stored.
           The collection must be present.
           If not specified, the ATR is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
 
           The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
-          If any part of the path contains a special character, that part of the path must be delimited in backticks `&grave;&grave;`.
+          If any part of the path contains a special character, that part of the path must be delimited in backticks &grave;&grave;.
 
-          The {atrcollection-srv}[node-level] `atrcollection` setting specifies the default for this parameter for a single node.
+          The [node-level][atrcollection-srv] `atrcollection` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting.
+
+          [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
+          [atrcollection-srv]: #atrcollection-srv
+        x-desc-refs: |
+          [atrcollection-srv]: admin.html#atrcollection-srv
         example: default:&grave;travel-sample&grave;.transaction.test
       auto_execute:
         type: boolean
+        x-desc-name: auto_execute
         description: |
-          [[auto_execute]]
+          [#auto_execute]
           Specifies that prepared statements should be executed automatically as soon as they are created.
           This saves you from having to make two separate requests in cases where you want to prepare a statement and execute it immediately.
 
-          Refer to {prepare-auto-execute}[Auto-Execute] for more information.
+          Refer to [Auto-Execute][auto-execute] for more information.
+
+          [auto-execute]: /server/7.6/n1ql/n1ql-language-reference/prepare.html#auto-execute
         default: false
         example: true
-      # batch_args:
-      #   type: array
-      #   description: |
-      #     [[batch_args]]
-      #     Applicable to POST requests only, containing UPDATE, INSERT, DELETE statements (DML statements) with _positional_ parameters.
-
-      #     An array of arrays.
-      #     The values in each inner array need to match the positional parameters in the statement.
-      # batch_named_args:
-      #   type: array
-      #   description: |
-      #     [[batch_named_args]]
-      #     Applicable to POST requests only, containing UPDATE, INSERT, DELETE statements (DML statements) with _named_ parameters.
-
-      #     An array of objects.
-      #     The keys in each object need to match the named parameters in the statement.
       client_context_id:
         type: string
+        x-desc-name: client_context_id
         description: |
-          [[client_context_id]]
+          [#client_context_id]
           A piece of data supplied by the client that is echoed in the response, if present.
-          {sqlpp} is agnostic about the content of this parameter; it is just echoed in the response.
+          SQL++ is agnostic about the content of this parameter; it is just echoed in the response.
 
           * Maximum allowed size is 64 characters; all others will be cut.
           * If it contains an escape character `/` or quote `"`, it will be rejected as error code 1110.
       compression:
         type: string
+        x-desc-name: compression
         description: |
-          [[compression]]
+          [#compression]
           Compression format to use for response data on the wire.
 
           Values are case-insensitive.
@@ -248,23 +253,29 @@ definitions:
         example: zip
       controls:
         type: boolean
+        x-desc-name: controls_req
         description: |
-          [[controls_req]]
+          [#controls_req]
           Specifies if there should be a controls section returned with the request results.
 
           When set to `true`, the query response document includes a controls section with runtime information provided along with the request, such as positional and named parameters or settings.
 
           If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
 
-          The {controls-srv}[node-level] `controls` setting specifies the default for this parameter for a single node.
+          The [node-level][controls-srv] `controls` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting.
+
+          [controls-srv]: #controls-srv
+        x-desc-refs: |
+          [controls-srv]: admin.html#controls-srv
         example: true
       creds:
         type: array
         items:
           $ref: "#/definitions/Credentials"
+        x-desc-name: creds
         description: |
-          [[creds]]
+          [#creds]
           Specifies the login credentials.
           The Query API supports two types of identity: local (or bucket) and admin.
 
@@ -279,38 +290,51 @@ definitions:
             pass: password
       durability_level:
         type: string
+        x-desc-name: durability_level
         description: |
-          [[durability_level]]
-          The level of {durability}[durability] for mutations produced by the request.
+          [#durability_level]
+          The level of [durability][durability] for mutations produced by the request.
 
-          If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the {tximplicit}[tximplicit] parameter set to `true`, the durability level is specified for all mutations within that transaction.
+          If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the [tximplicit](#tximplicit) parameter set to `true`, the durability level is specified for all mutations within that transaction.
 
           Durability is also supported for non-transactional DML statements.
           In this case, the `kvtimeout` parameter is used as the durability timeout.
 
           If not specified, the default durability level is `"majority"`.
           Set the durability level to `"none"` or `""` to specify no durability.
-        enum: ['""', "none", "majority", "majorityAndPersistActive", "persistToMajority"]
+
+          [durability]: /server/7.6/learn/data/durability.html
+        enum:
+        # Workaround for swagger2markup.
+        # Remove the &quot; entities for Redocly.
+          - "&quot;&quot;"
+          - none
+          - majority
+          - majorityAndPersistActive
+          - persistToMajority
         default: majority
         example: none
       encoded_plan:
         type: string
+        x-desc-name: encoded_plan
         description: |
-          [[encoded_plan]]
+          [#encoded_plan]
           In Couchbase Server 6.5 and later, this parameter is ignored and has no effect.
           It is included for compatibility with previous versions of Couchbase Server.
       encoding:
         type: string
+        x-desc-name: encoding
         description: |
-          [[encoding]]
+          [#encoding]
           Desired character encoding for the query results.
 
           Only possible value is `UTF-8` and is case-insensitive.
         default: UTF-8
       format:
         type: string
+        x-desc-name: format
         description: |
-          [[format]]
+          [#format]
           Desired format for the query results.
 
           Values are case-insensitive.
@@ -319,8 +343,9 @@ definitions:
         example: XML
       kvtimeout:
         type: string
+        x-desc-name: kvtimeout
         description: |
-          [[kvtimeout]]
+          [#kvtimeout]
           The maximum time to wait for a KV operation before timing out.
           Only applies to statements within a transaction, or to non-transactional statements when the `durability_level` is set.
 
@@ -342,27 +367,35 @@ definitions:
       max_parallelism:
         type: integer
         format: int32
+        x-desc-name: max_parallelism_req
         description: |
-          [[max_parallelism_req]]
+          [#max_parallelism_req]
           Specifies the maximum parallelism for the query.
 
-          The {max-parallelism-srv}[node-level] `max-parallelism` setting specifies the ceiling for this parameter for a single node.
+          The [node-level][max-parallelism-srv] `max-parallelism` setting specifies the ceiling for this parameter for a single node.
           If the request-level parameter is zero or negative, the parallelism for the query is set to the node-level setting.
           If the request-level parameter is greater than zero and less than the node-level setting, the request-level parameter overrides the node-level setting.
           If the request-level parameter is greater than the node-level setting, the parallelism for the query is set to the node-level setting.
 
-          In addition, the {queryMaxParallelism}[cluster-level] `queryMaxParallelism` setting specifies the ceiling for this parameter for the whole cluster.
+          In addition, the [cluster-level][queryMaxParallelism] `queryMaxParallelism` setting specifies the ceiling for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
           To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
 
           The default value is the same as the number of partitions of the index selected for the query.
+
+          [max-parallelism-srv]: #max-parallelism-srv
+          [queryMaxParallelism]: #queryMaxParallelism
+        x-desc-refs: |
+          [max-parallelism-srv]: admin.html#max-parallelism-srv
+          [queryMaxParallelism]: ../../rest-api/rest-cluster-query-settings.html#queryMaxParallelism
         example: 3
       memory_quota:
         type: integer
         format: int32
+        x-desc-name: memory_quota_req
         description: |
-          [[memory_quota_req]]
+          [#memory_quota_req]
           Specifies the maximum amount of memory the request may use, in MB.
 
           Specify `0` (the default value) to disable.
@@ -371,84 +404,117 @@ definitions:
           Within a transaction, this parameter enforces the memory quota for the transaction.
           The transaction memory quota tracks only the delta table and the transaction log (approximately).
 
-          The {memory-quota-srv}[node-level] `memory-quota` setting specifies the ceiling for this parameter for a single node.
+          The [node-level][memory-quota-srv] `memory-quota` setting specifies the ceiling for this parameter for a single node.
           If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.
           If the node-level setting is greater than zero, the request-level parameter is capped by the node-level setting.
 
-          In addition, the {queryMemoryQuota}[cluster-level] `queryMemoryQuota` setting specifies the ceiling for this parameter for the whole cluster.
+          In addition, the [cluster-level][queryMemoryQuota] `queryMemoryQuota` setting specifies the ceiling for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+          [memory-quota-srv]: #memory-quota-srv
+          [queryMemoryQuota]: #queryMemoryQuota
+        x-desc-refs: |
+          [memory-quota-srv]: admin.html#memory-quota-srv
+          [queryMemoryQuota]: ../../rest-api/rest-cluster-query-settings.html#queryMemoryQuota
         default: 0
         example: 4
       metrics:
         type: boolean
+        x-desc-name: metrics
         description: |
-          [[metrics]]
+          [#metrics]
           Specifies that metrics should be returned with query results.
         default: true
         example: false
       namespace:
         type: string
+        x-desc-name: namespace
         description: >
-          [[namespace]]
           Specifies the namespace to use.
           Currently, only the `default` namespace is available.
         example: default
       numatrs:
         type: integer
         format: int32
+        x-desc-name: numatrs_req
         description: |
-          [[numatrs_req]]
-          Specifies the total number of {transactions-understanding-transactions}[active transaction records].
+          [#numatrs_req]
+          Specifies the total number of [active transaction records][additional-storage-use].
           Must be a positive integer.
 
-          The {numatrs-srv}[node-level] `numatrs` setting specifies the default for this parameter for a single node.
+          The [node-level][numatrs-srv] `numatrs` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting.
 
-          In addition, the {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
+          In addition, the [cluster-level][queryNumAtrs] `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+          [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
+          [numatrs-srv]: #numatrs-srv
+          [queryNumAtrs]: #queryNumAtrs
+        x-desc-refs: |
+          [numatrs-srv]: admin.html#numatrs-srv
+          [queryNumAtrs]: ../../rest-api/rest-cluster-query-settings.html#queryNumAtrs
         default: 1024
         example: 512
       pipeline_batch:
         type: integer
         format: int32
+        x-desc-name: pipeline_batch_req
         description: |
-          [[pipeline_batch_req]]
+          [#pipeline_batch_req]
           Controls the number of items execution operators can batch for Fetch from the KV.
 
-          The {pipeline-batch-srv}[node-level] `pipeline-batch` setting specifies the default for this parameter for a single node.
+          The [node-level][pipeline-batch-srv] `pipeline-batch` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
-          In addition, the {queryPipelineBatch}[cluster-level] `queryPipelineBatch` setting specifies the default for this parameter for the whole cluster.
+          In addition, the [cluster-level][queryPipelineBatch] `queryPipelineBatch` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+          [pipeline-batch-srv]: #pipeline-batch-srv
+          [queryPipelineBatch]: #queryPipelineBatch
+        x-desc-refs: |
+          [pipeline-batch-srv]: admin.html#pipeline-batch-srv
+          [queryPipelineBatch]: ../../rest-api/rest-cluster-query-settings.html#queryPipelineBatch
         example: 64
       pipeline_cap:
         type: integer
         format: int32
+        x-desc-name: pipeline_cap_req
         description: |
-          [[pipeline_cap_req]]
+          [#pipeline_cap_req]
           Maximum number of items each execution operator can buffer between various operators.
 
-          The {pipeline-cap-srv}[node-level] `pipeline-cap` setting specifies the default for this parameter for a single node.
+          The [node-level][pipeline-cap-srv] `pipeline-cap` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
-          In addition, the {queryPipelineCap}[cluster-level] `queryPipelineCap` setting specifies the default for this parameter for the whole cluster.
+          In addition, the [cluster-level][queryPipelineCap] `queryPipelineCap` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+          [pipeline-cap-srv]: #pipeline-cap-srv
+          [queryPipelineCap]: #queryPipelineCap
+        x-desc-refs: |
+          [pipeline-cap-srv]: admin.html#pipeline-cap-srv
+          [queryPipelineCap]: ../../rest-api/rest-cluster-query-settings.html#queryPipelineCap
         example: 1024
       prepared:
         type: string
+        x-desc-name: prepared
         description: |
-          [[prepared]]
+          [#prepared]
           _Required_ if `statement` not provided.
 
-          The name of the prepared {sqlpp} statement to be executed.
-          Refer to {execute}[EXECUTE] for examples.
+          The name of the prepared SQL++ statement to be executed.
+          Refer to [EXECUTE][execute] for examples.
 
           If both `prepared` and `statement` are present and non-empty, an error is returned.
+
+          [execute]: /server/7.6/n1ql/n1ql-language-reference/execute.html
         example: "[127.0.0.1:8091]pricy_hotel"
       preserve_expiry:
         type: boolean
+        x-desc-name: preserve_expiry
         description: |
-          [[preserve_expiry]]
+          [#preserve_expiry]
           Specifies whether documents should keep their current expiration setting when modified by a DML statement.
 
           If `true`, documents will keep any existing expiration setting when modified by a DML statement.
@@ -461,40 +527,51 @@ definitions:
         example: true
       pretty:
         type: boolean
+        x-desc-name: pretty_req
         description: |
-          [[pretty_req]]
+          [#pretty_req]
           Specifies the query results returned in pretty format.
 
-          The {pretty-srv}[node-level] `pretty` setting specifies the default for this parameter for a single node.
+          The [node-level][pretty-srv] `pretty` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting.
+
+          [pretty-srv]: #pretty-srv
+        x-desc-refs: |
+          [pretty-srv]: admin.html#pretty-srv
         example: false
       profile:
         type: string
+        x-desc-name: profile_req
         description: |
-          [[profile_req]]
+          [#profile_req]
           Specifies if there should be a profile section returned with the request results.
           The valid values are:
 
-          `off`:: No profiling information is added to the query response.
+          * `off` &mdash; No profiling information is added to the query response.
 
-          `phases`::
+          * `phases` &mdash;
           The query response includes a profile section with stats and details about various phases of the query plan and execution.
           Three phase times will be included in the `system:active_requests` and `system:completed_requests` monitoring keyspaces.
 
-          `timings`::
+          * `timings` &mdash;
           Besides the phase times, the profile section of the query response document will include a full query plan with timing and information about the number of processed documents at each phase.
           This information will be included in the `system:active_requests` and `system:completed_requests` keyspaces.
 
           If `profile` is not set as one of the above values, then the profile setting does not change.
 
-          The {profile-srv}[node-level] `profile` setting specifies the default for this parameter for a single node.
+          The [node-level][profile-srv] `profile` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting.
+
+          [profile-srv]: #profile-srv
+        x-desc-refs: |
+          [profile-srv]: admin.html#profile-srv
         enum: ["off", "phases", "timings"]
         example: phases
       query_context:
         type: string
+        x-desc-name: query_context
         description: |
-          [[query_context]]
+          [#query_context]
           Specifies the namespace, bucket, and scope used to resolve partial keyspace references within the request.
 
           The query context may be a _full path_, containing namespace, bucket, and scope; or a _relative path_, containing just the bucket and scope.
@@ -504,8 +581,9 @@ definitions:
         example: default:travel-sample.inventory
       readonly:
         type: boolean
+        x-desc-name: readonly
         description: |
-          [[readonly]]
+          [#readonly]
           Controls whether a query can change a resulting recordset.
 
           If `readonly` is `true`, then the following statements are not allowed:
@@ -523,45 +601,52 @@ definitions:
       scan_cap:
         type: integer
         format: int32
+        x-desc-name: scan_cap_req
         description: |
-          [[scan_cap_req]]
+          [#scan_cap_req]
           Maximum buffered channel size between the indexer client and the query service for index scans.
           This parameter controls when to use scan backfill.
 
           Use `0` or a negative number to disable.
           Smaller values reduce GC, while larger values reduce indexer backfill.
 
-          The {scan-cap-srv}[node-level] `scan-cap` setting specifies the default for this parameter for a single node.
+          The [node-level][scan-cap-srv] `scan-cap` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
-          In addition, the {queryScanCap}[cluster-level] `queryScanCap` setting specifies the default for this parameter for the whole cluster.
+          In addition, the [cluster-level][queryScanCap] `queryScanCap` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+          [scan-cap-srv]: #scan-cap-srv
+          [queryScanCap]: #queryScanCap
+        x-desc-refs: |
+          [scan-cap-srv]: admin.html#scan-cap-srv
+          [queryScanCap]: ../../rest-api/rest-cluster-query-settings.html#queryScanCap
         example: 1024
       scan_consistency:
         type: string
+        x-desc-name: scan_consistency
         description: |
-          [[scan_consistency]]
+          [#scan_consistency]
           Specifies the consistency guarantee or constraint for index scanning.
           The valid values are:
 
-          `not_bounded`::
+          * `not_bounded` &mdash;
           No timestamp vector is used in the index scan.
           This is the fastest mode, because it avoids the costs of obtaining the vector and waiting for the index to catch up to the vector.
 
-          `at_plus`::
+          * `at_plus` &mdash;
           This implements bounded consistency.
           The request includes a `scan_vector` parameter and value, which is used as a lower bound.
           This can be used to implement read-your-own-writes (RYOW).
 
-          `request_plus`::
+          * `request_plus` &mdash;
           This implements strong consistency per request.
           Before processing the request, a current vector is obtained.
           The vector is used as a lower bound for the statements in the request.
           If there are DML statements in the request, RYOW is also applied within the request.
-          +
-          If `request_plus` is specified in a query that runs during a failover of an index node, the query waits until the rebalance operation completes and the index data has rebalanced before returning a result.
+          (If `request_plus` is specified in a query that runs during a failover of an index node, the query waits until the rebalance operation completes and the index data has rebalanced before returning a result.)
 
-          `statement_plus`::
+          * `statement_plus` &mdash;
           This implements strong consistency per statement.
           Before processing each statement, a current vector is obtained and used as a lower bound for that statement.
 
@@ -570,29 +655,32 @@ definitions:
           For multi-statement requests, the default behavior is RYOW within each request.
           If you want to disable RYOW within a request, add a separate `request_consistency` parameter that can be set to `not_bounded`.
 
-          If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the {tximplicit}[tximplicit] parameter set to `true`, then this parameter sets the transactional scan consistency.
-          Refer to {transactional-scan-consistency}[Transactional Scan Consistency] for details.
+          If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the [tximplicit](#tximplicit) parameter set to `true`, then this parameter sets the transactional scan consistency.
+          Refer to [Transactional Scan Consistency][transactional-scan-consistency] for details.
+
+          [transactional-scan-consistency]: /server/7.6/settings/query-settings.html#transactional-scan-consistency
         enum: ["not_bounded", "at_plus", "request_plus", "statement_plus"]
         default: not_bounded
         example: at_plus
       scan_vector:
         type: object
         x-type: array
+        x-desc-name: scan_vector
         description: |
-          [[scan_vector]]
+          [#scan_vector]
           _Required_ if `scan_consistency` is `at_plus` and `scan_vectors` not provided.
 
           Specify the lower bound vector timestamp for one keyspace when using `at_plus` scan consistency.
 
-          Scan vectors are built of two-element +[+[.var]`value`, [.var]`guard`] entries:
+          Scan vectors are built of two-element [`value`, `guard`] entries:
 
-          * [.var]`value`: a vBucket's sequence number (a JSON number)
-          * [.var]`guard`: a vBucket's UUID (a string)
+          * `value`: a vBucket's sequence number (a JSON number)
+          * `guard`: a vBucket's UUID (a string)
 
           Scan vectors have two forms:
 
-          . *Full scan vector*: an array of +[+[.var]`value`, [.var]`guard`] entries, giving an entry for every vBucket in the system.
-          . *Sparse scan vectors*: an object providing entries for specific vBuckets, mapping a vBucket number (a string) to each +[+[.var]`value`, [.var]`guard`] entry.
+          1. Full: an array of [`value`, `guard`] entries, giving an entry for every vBucket in the system.
+          2. Sparse: an object providing entries for specific vBuckets, mapping a vBucket number (a string) to each [`value`, `guard`] entry.
 
           Note that `scan_vector` can only be used if the query uses at most one keyspace; if it is used for a query referencing more than one keyspace, the query will fail with an error.
 
@@ -607,8 +695,9 @@ definitions:
       scan_vectors:
         type: object
         x-type: array
+        x-desc-name: scan_vectors
         description: |
-          [[scan_vectors]]
+          [#scan_vectors]
           _Required_ if `scan_consistency` is `at_plus` and `scan_vector` not provided.
 
           A map from keyspace names to scan vectors.
@@ -618,8 +707,9 @@ definitions:
       scan_wait:
         type: string
         format: duration
+        x-desc-name: scan_wait
         description: |
-          [[scan_wait]]
+          [#scan_wait]
           Can be supplied with `scan_consistency` values of `request_plus`, `statement_plus` and `at_plus`.
 
           Specifies the maximum time the client is willing to wait for an index to catch up to the vector timestamp in the request.
@@ -642,22 +732,24 @@ definitions:
         example: 30m
       signature:
         type: boolean
+        x-desc-name: signature
         description: |
-          [[signature]]
+          [#signature]
           Include a header for the results schema in the response.
         default: true
         example: false
       statement:
         type: string
+        x-desc-name: statement
         description: |
-          [[statement]]
+          [#statement]
           _Required_ if `prepared` not provided.
 
-          Any valid {sqlpp} statement for a POST request, or a read-only {sqlpp} statement (SELECT, EXPLAIN) for a GET request.
+          Any valid SQL++ statement for a POST request, or a read-only SQL++ statement (SELECT, EXPLAIN) for a GET request.
 
           If both `prepared` and `statement` are present and non-empty, an error is returned.
 
-          '''
+          ----
 
           When specifying the request parameters as form data, the statement may not contain an unescaped semicolon (`;`).
           If it does, the Query Service responds with error 1040.
@@ -668,8 +760,9 @@ definitions:
       timeout:
         type: string
         format: duration
+        x-desc-name: timeout_req
         description: |
-          [[timeout_req]]
+          [#timeout_req]
           Maximum time to spend on the request before timing out.
 
           The value for this parameter is a string.
@@ -686,27 +779,35 @@ definitions:
           Specify a duration of `0` or a negative duration to disable.
           When disabled, no timeout is applied and the request runs for however long it takes.
 
-          If {txid}[txid] or {tximplicit}[tximplicit] is set, this parameter is ignored.
+          If [tximplicit](#tximplicit) or [txid](#txid) is set, this parameter is ignored.
           The request inherits the remaining time of the transaction as timeout.
 
-          The {timeout-srv}[node-level] `timeout` setting specifies the default for this parameter for a single node.
+          The [node-level][timeout-srv] `timeout` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting.
           However, if the node-level setting is greater than 0, the timeout for the query is limited to the node-level setting.
 
-          In addition, the {queryTimeout}[cluster-level] `queryTimeout` setting specifies the default for this parameter for the whole cluster.
+          In addition, the [cluster-level][queryTimeout] `queryTimeout` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+          [timeout-srv]: #timeout-srv
+          [queryTimeout]: #queryTimeout
+        x-desc-refs: |
+          [timeout-srv]: admin.html#timeout-srv
+          [queryTimeout]: ../../rest-api/rest-cluster-query-settings.html#queryTimeout
         example: 30m
       txdata:
         type: object
+        x-desc-name: txdata
         description: |
-          [[txdata]]
+          [#txdata]
           Transaction data.
           For internal use only.
       txid:
         type: string
         format: UUID
+        x-desc-name: txid
         description: |
-          [[txid]]
+          [#txid]
           _Required_ for statements within a transaction.
 
           Transaction ID.
@@ -718,22 +819,24 @@ definitions:
         example: d81d9b4a-b758-4f98-b007-87ba262d3a51
       tximplicit:
         type: boolean
+        x-desc-name: tximplicit
         description: |
-          [[tximplicit]]
+          [#tximplicit]
           Specifies that a DML statement is a singleton transaction.
 
           When this parameter is true, the Query service starts a transaction and executes the statement.
           If execution is successful, the Query service commits the transaction; otherwise the transaction is rolled back.
 
           The statement may not be part of an ongoing transaction.
-          If the {txid}[txid] request-level parameter is set, the `tximplicit` parameter is ignored.
+          If the [txid](#txid) request-level parameter is set, the `tximplicit` parameter is ignored.
         default: false
         example: true
       txstmtnum:
         type: integer
         format: int32
+        x-desc-name: txstmtnum
         description: |
-          [[txstmtnum]]
+          [#txstmtnum]
           Transaction statement number.
           The transaction statement number must be a positive integer, and must be higher than any previous transaction statement numbers in the transaction.
           If the transaction statement number is lower than the transaction statement number for any previous statement, an error is generated.
@@ -741,13 +844,14 @@ definitions:
       txtimeout:
         type: string
         format: duration
+        x-desc-name: txtimeout_req
         description: |
-          [[txtimeout_req]]
+          [#txtimeout_req]
           Maximum time to spend on a transaction before timing out.
-          Only applies to `BEGIN TRANSACTION` statements, or DML statements for which {tximplicit}[tximplicit] is set.
+          Only applies to `BEGIN TRANSACTION` statements, or DML statements for which [tximplicit](#tximplicit) is set.
           For other statements, it is ignored.
 
-          Within a transaction, the request-level {timeout_req}[timeout] parameter is ignored.
+          Within a transaction, the request-level [timeout](#timeout_req) parameter is ignored.
           The transaction timeout clock starts when the `BEGIN WORK` statement is successful.
           Once the transaction timeout is reached, no statement is allowed to continue in the transaction.
 
@@ -765,32 +869,46 @@ definitions:
           Specify a duration of `0` to disable.
           When disabled, the request-level timeout is set to the default.
 
-          The {txtimeout-srv}[node-level] `txtimeout` setting specifies the default for this parameter for a single node.
+          The [node-level][txtimeout-srv] `txtimeout` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting.
           However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
 
-          In addition, the {queryTxTimeout}[cluster-level] `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
+          In addition, the [cluster-level][queryTxTimeout] `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
           The default is `"15s"` for cbq files or scripts, `"2m"` for interactive cbq sessions or redirected input.
+
+          [txtimeout-srv]: #txtimeout-srv
+          [queryTxTimeout]: #queryTxTimeout
+        x-desc-refs: |
+          [txtimeout-srv]: admin.html#txtimeout-srv
+          [queryTxTimeout]: ../../rest-api/rest-cluster-query-settings.html#queryTxTimeout
         example: 30m
       use_cbo:
         type: boolean
+        x-desc-name: use_cbo_req
         description: |
-          [[use_cbo_req]]
+          [#use_cbo_req]
           Specifies whether the cost-based optimizer is enabled.
 
-          The {use-cbo-srv}[node-level] `use-cbo` setting specifies the default for this parameter for a single node.
+          The [node-level][use-cbo-srv] `use-cbo` setting specifies the default for this parameter for a single node.
           The request-level parameter overrides the node-level setting.
 
-          In addition, the {queryUseCBO}[cluster-level] `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
+          In addition, the [cluster-level][queryUseCBO] `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+          [use-cbo-srv]: #use-cbo-srv
+          [queryUseCBO]: #queryUseCBO
+        x-desc-refs: |
+          [use-cbo-srv]: admin.html#use-cbo-srv
+          [queryUseCBO]: ../../rest-api/rest-cluster-query-settings.html#queryUseCBO
         example: true
       use_fts:
         type: boolean
+        x-desc-name: use_fts
         description: |
-          [[use_fts]]
-          [.edition]#{enterprise}#
+          [#use_fts]
+          &blacktriangleright; [ENTERPRISE EDITION](https://www.couchbase.com/products/editions)
 
           Specifies that the query should use a full-text index.
 
@@ -800,26 +918,31 @@ definitions:
           If a qualified full-text index is available, it is selected for the query.
           If none of the available full-text indexes are qualified, the available GSI indexes are considered instead.
 
-          Refer to {flex-indexes}[Flex Indexes] for more information.
+          Refer to [Flex Indexes][flex-indexes] for more information.
+
+          [flex-indexes]: /server/7.6/n1ql/n1ql-language-reference/flex-indexes.html
         default: false
         example: true
       $<identifier>:
         type: string
         format: any JSON value
+        x-desc-name: identifier
         description: |
-          [[identifier]]
+          [#identifier]
           Applicable if the `statement` has 1 or more named parameters.
 
           The name of a named parameter consists of two parts:
 
-          . The $ character
-          . An identifier that starts with an alpha character followed by one or more alphanumeric characters.
+          1. The `$` character.
+          2. An identifier that starts with an alpha character followed by one or more alphanumeric characters.
 
           The value of the named parameter is any JSON value.
 
           Named parameters apply to `prepared` also.
 
-          Refer to {section_srh_tlm_n1b}[] for details.
+          Refer to [Named Parameters and Positional Parameters][section_srh_tlm_n1b] for details.
+
+          [section_srh_tlm_n1b]: /server/7.6/settings/query-settings.html#section_srh_tlm_n1b
 
   Credentials:
     type: object
@@ -845,7 +968,7 @@ definitions:
         description: A unique identifier for the response.
       clientContextID:
         type: string
-        description: The client context ID of the request, if one was supplied &mdash; see `client_context_id` in {request-parameters}[].
+        description: The client context ID of the request, if one was supplied &mdash; see `client_context_id` in [Request Parameters](#_request_parameters).
       signature:
         type: object
         description: >
@@ -891,7 +1014,7 @@ definitions:
         type: object
         description: >
           An object containing runtime information provided along with the request.
-          Present only if `controls` was set to true in the {request-parameters}[].
+          Present only if `controls` was set to true in the [Request Parameters](#_request_parameters).
         $ref: "#/definitions/Controls"
 
   Conditions:
@@ -927,7 +1050,7 @@ definitions:
       sev:
         type: integer
         description: |
-          One of the following {sqlpp} severity levels, listed in order of severity:
+          One of the following SQL++ severity levels, listed in order of severity:
 
            1. Severe
            2. Error

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -947,9 +947,13 @@ definitions:
           In addition, the [cluster-level][queryUseReplica] `queryUseReplica` setting specifies the default for this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-          WARNING: Do not enable read from replica when you require consistent results.
+          Do not enable read from replica when you require consistent results.
+          Only SELECT queries that are not within a transaction can read from replica.
 
-          SELECT queries within a transaction cannot read from replica.
+          Reading from replica is only possible if the cluster uses Couchbase Server 7.6.0 or later.
+
+          Note that KV range scans cannot currently be started on a replica vBucket.
+          If a query uses sequential scan and a data node becomes unavailable, the query might return an error, even if read from replica is enabled for the request.
 
           [use-replica-srv]: #use-replica-srv
           [queryUseReplica]: #queryUseReplica

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -923,6 +923,40 @@ definitions:
           [flex-indexes]: /server/7.6/n1ql/n1ql-language-reference/flex-indexes.html
         default: false
         example: true
+      use_replica:
+        type: string
+        default: unset
+        enum: ["off","on","unset"]
+        example: on
+        x-desc-name: use_replica_req
+        description: |
+          [#use_replica_req]
+          Specifies whether a query can fetch data from a replica vBucket if active vBuckets are inaccessible.
+          The possible values are:
+
+          * `off` &mdash; read from replica is disabled for this request.
+
+          * `on` &mdash; read from replica is enabled for this request, unless it has been disabled for all requests at node level.
+
+          * `unset` &mdash; read from replica is specified by the node-level setting.
+          If the node-level setting is also `unset`, read from replica is disabled for this request.
+
+          The [node-level][use-replica-srv] `use-replica` setting specifies the default for this property for a single node.
+          The request-level parameter usually overrides the node-level setting.
+          However, when the node-level setting is `off`, the request-level parameter cannot enable the property.
+
+          In addition, the [cluster-level][queryUseReplica] `queryUseReplica` setting specifies the default for this property for the whole cluster.
+          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
+          WARNING: Do not enable read from replica when you require consistent results.
+
+          SELECT queries within a transaction cannot read from replica.
+
+          [use-replica-srv]: #use-replica-srv
+          [queryUseReplica]: #queryUseReplica
+        x-desc-refs: |
+          [use-replica-srv]: admin.html#use-replica-srv
+          [queryUseReplica]: ../../rest-api/rest-cluster-query-settings.html#queryUseReplica
       $<identifier>:
         type: string
         format: any JSON value

--- a/src/query-settings/query-settings.gradle
+++ b/src/query-settings/query-settings.gradle
@@ -10,7 +10,7 @@ convertSwagger2markup {
               'swagger2markup.definitionOrderBy' : 'AS_IS',
               'swagger2markup.parameterOrderBy' : 'AS_IS',
               'swagger2markup.propertyOrderBy' : 'AS_IS',
-              'swagger2markup.swaggerMarkupLanguage' : 'ASCIIDOC',
+              'swagger2markup.swaggerMarkupLanguage' : 'MARKDOWN',
               'swagger2markup.flatBodyEnabled' : false,
               'swagger2markup.extensions.springRestDocs.snippetBaseUri' : file('extensions/spring').absolutePath,
               'swagger2markup.extensions.springRestDocs.markupLanguage' : 'ASCIIDOC',

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -8,8 +8,8 @@ info:
 
     The API schemes and host URLs are as follows:
 
-    * `http://node:8091/`
-    * `https://node:18091/` (for secure access)
+    * http://node:8091/
+    * https://node:18091/ (for secure access)
 
     where `node` is the host name or IP address of a node running the Query service.
 
@@ -88,7 +88,14 @@ paths:
           schema:
             type: object
 
-# Use attributes for xrefs so that they can point to different locations in different contexts
+# The output of this spec is used in more than one location, so Markdown cannot use relative links.
+# Absolute links begin with /server/7.6 -- this must be replaced for every branch.
+# Relative links are currently expected to point to a location in the same page.
+# The x-desc-refs attribute records links which point to other REST API references, for future use.
+# The x-desc-name attribute records the ID of the parameter description, also for future use.
+
+# The swagger2markup Markdown converter does not recognize HTML tags like <a id="foo">.
+# For the moment we have to use the AsciiDoc markup [#foo], which is passed through unchanged.
 
 definitions:
   Settings:
@@ -99,30 +106,41 @@ definitions:
         type: boolean
         default: true
         example: false
+        x-desc-name: queryCleanupClientAttempts
         description: |
-          [[queryCleanupClientAttempts]]
+          [#queryCleanupClientAttempts]
           When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
 
-          The {cleanupclientattempts}[node-level] `cleanupclientattempts` setting specifies this property for a single node.
+          The [node-level][cleanupclientattempts] `cleanupclientattempts` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [cleanupclientattempts]: #cleanupclientattempts
+        x-desc-refs: |
+          [cleanupclientattempts]: ../n1ql/n1ql-rest-api/admin.html#cleanupclientattempts
       queryCleanupLostAttempts:
         type: boolean
         default: true
         example: false
+        x-desc-name: queryCleanupLostAttempts
         description: |
-          [[queryCleanupLostAttempts]]
+          [#queryCleanupLostAttempts]
           When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
 
-          The {cleanuplostattempts}[node-level] `cleanuplostattempts` setting specifies this property for a single node.
+          The [node-level][cleanuplostattempts] `cleanuplostattempts` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [cleanuplostattempts]: #cleanuplostattempts
+        x-desc-refs: |
+          [cleanuplostattempts]: ../n1ql/n1ql-rest-api/admin.html#cleanuplostattempts
       queryCleanupWindow:
         type: string
         format: duration
         default: 60s
         example: 30s
+        x-desc-name: queryCleanupWindow
         description: |
-          [[queryCleanupWindow]]
-          Specifies how frequently the Query service checks its subset of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for cleanup.
+          [#queryCleanupWindow]
+          Specifies how frequently the Query service checks its subset of [active transaction records][additional-storage-use] for cleanup.
           Decreasing this setting causes expiration transactions to be found more swiftly, with the tradeoff of increasing the number of reads per second used for the scanning process.
 
           The value for this setting is a string.
@@ -136,81 +154,104 @@ definitions:
           * `m` (minutes)
           * `h` (hours)
 
-          The {cleanupwindow}[node-level] `cleanupwindow` setting specifies this property for a single node.
+          The [node-level][cleanupwindow] `cleanupwindow` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
+          [cleanupwindow]: #cleanupwindow
+        x-desc-refs: |
+          [cleanupwindow]: ../n1ql/n1ql-rest-api/admin.html#cleanupwindow
       queryCompletedLimit:
         type: integer
         format: int32
         default: 4000
         example: 7000
+        x-desc-name: queryCompletedLimit
         description: |
-          [[queryCompletedLimit]]
+          [#queryCompletedLimit]
           Sets the number of requests to be logged in the completed requests catalog.
           As new completed requests are added, old ones are removed.
 
           Increase this when the completed request keyspace is not big enough to track the slow requests, such as when you want a larger sample of slow requests.
 
-          Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples.
+          Refer to [Configure the Completed Requests][sys-completed-config] for more information and examples.
 
-          The {completed-limit-srv}[node-level] `completed-limit` setting specifies this property for a single node.
+          The [node-level][completed-limit] `completed-limit` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [sys-completed-config]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config
+          [completed-limit]: #completed-limit
+        x-desc-refs: |
+          [completed-limit]: ../n1ql/n1ql-rest-api/admin.html#completed-limit
       queryCompletedThreshold:
         type: integer
         format: int32
         default: 1000
         example: 7000
+        x-desc-name: queryCompletedThreshold
         description: |
-          [[queryCompletedThreshold]]
+          [#queryCompletedThreshold]
           A duration in milliseconds.
           All completed queries lasting longer than this threshold are logged in the completed requests catalog.
 
           Specify `0` to track all requests, independent of duration.
           Specify any negative number to track none.
 
-          Refer to xref:manage:monitor/monitoring-n1ql-query.adoc#sys-completed-config[Configure the Completed Requests] for more information and examples.
+          Refer to [Configure the Completed Requests][sys-completed-config] for more information and examples.
 
-          The {completed-threshold-srv}[node-level] `completed-threshold` setting specifies this property for a single node.
+          The [node-level][completed-threshold] `completed-threshold` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [sys-completed-config]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-completed-config
+          [completed-threshold]: #completed-threshold
+        x-desc-refs: |
+          [completed-threshold]: ../n1ql/n1ql-rest-api/admin.html#completed-threshold
       queryLogLevel:
         type: string
         default: INFO
         enum: ["DEBUG","TRACE","INFO","WARN","ERROR","SEVERE","NONE"]
         example: DEBUG
+        x-desc-name: queryLogLevel
         description: |
-          [[queryLogLevel]]
+          [#queryLogLevel]
           Log level used in the logger.
 
-          All values, in descending order of data:{blank}
+          All values, in descending order of data:
 
-          `DEBUG` -- For developers.
+          * `DEBUG` &mdash; For developers.
           Writes everything.
 
-          `TRACE` -- For developers.
+          * `TRACE` &mdash; For developers.
           Less info than `DEBUG`.
 
-          `INFO` -- For admin & customers.
+          * `INFO` &mdash; For admin & customers.
           Lists warnings & errors.
 
-          `WARN` -- For admin.
+          * `WARN` &mdash; For admin.
           Only abnormal items.
 
-          `ERROR` -- For admin.
+          * `ERROR` &mdash; For admin.
           Only errors to be fixed.
 
-          `SEVERE` -- For admin.
+          * `SEVERE` &mdash; For admin.
           Major items, like crashes.
 
-          `NONE` -- Doesn’t write anything.
+          * `NONE` &mdash; Doesn't write anything.
 
-          The {loglevel-srv}[node-level] `loglevel` setting specifies this property for a single node.
+          The [node-level][loglevel] `loglevel` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [loglevel]: #loglevel
+        x-desc-refs: |
+          [loglevel]: ../n1ql/n1ql-rest-api/admin.html#loglevel
       queryMaxParallelism:
         type: integer
         format: int32
         default: 1
         example: 0
+        x-desc-name: queryMaxParallelism
         description: |
-          [[queryMaxParallelism]]
+          [#queryMaxParallelism]
           Specifies the maximum parallelism for queries on all Query nodes in the cluster.
 
           If the value is zero or negative, the maximum parallelism is restricted to the number of allowed cores.
@@ -220,43 +261,61 @@ definitions:
           In Community Edition, the number of allowed cores cannot be greater than 4.
           In Enterprise Edition, there is no limit to the number of allowed cores.)
 
-          The {max-parallelism-srv}[node-level] `max-parallelism` setting specifies this property for a single node.
+          The [node-level][max-parallelism-srv] `max-parallelism` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, there is a {max_parallelism_req}[request-level] `max_parallelism` parameter.
+          In addition, there is a [request-level][max_parallelism_req] `max_parallelism` parameter.
           If a request includes this parameter, it will be capped by the node-level `max-parallelism` setting.
 
-          [NOTE]
-          To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
+          NOTE: To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
+          
+          Refer to [Max Parallelism][max-parallelism] for more information.
 
-          Refer to xref:n1ql:n1ql-language-reference/index-partitioning.adoc#max-parallelism[Max Parallelism] for more information.
+          [max-parallelism]: /server/7.6/n1ql/n1ql-language-reference/index-partitioning.html#max-parallelism
+          [max-parallelism-srv]: #max-parallelism-srv
+          [max_parallelism_req]: #max_parallelism_req
+        x-desc-refs: |
+          [max-parallelism-srv]: ../n1ql/n1ql-rest-api/admin.html#max-parallelism-srv
+          [max_parallelism_req]: ../n1ql/n1ql-rest-api/index.html#max_parallelism_req
       queryMemoryQuota:
         type: integer
         format: int32
         default: 0
         example: 4
+        x-desc-name: queryMemoryQuota
         description: |
-          [[queryMemoryQuota]]
+          [#queryMemoryQuota]
           Specifies the maximum amount of memory a request may use on any Query node in the cluster, in MB.
 
           Within a transaction, this setting enforces the memory quota for the transaction.
           The transaction memory quota tracks only the delta table and the transaction log (approximately).
 
-          The {memory-quota-srv}[node-level] `memory-quota` setting specifies this property for a single node.
+          The [node-level][memory-quota-srv] `memory-quota` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, there is a {memory_quota_req}[request-level] `memory_quota` parameter.
+          In addition, there is a [request-level][memory_quota_req] `memory_quota` parameter.
           If a request includes this parameter, it will be capped by the node-level `memory-quota` setting.
+
+          [memory-quota-srv]: #memory-quota-srv
+          [memory_quota_req]: #memory_quota_req
+        x-desc-refs: |
+          [memory-quota-srv]: ../n1ql/n1ql-rest-api/admin.html#memory-quota-srv
+          [memory_quota_req]: ../n1ql/n1ql-rest-api/index.html#memory_quota_req
       queryN1qlFeatCtrl:
         type: integer
         format: int32
+        x-desc-name: queryN1qlFeatCtrl
         description: |
-          [[queryN1qlFeatCtrl]]
-          {sqlpp} feature control.
+          [#queryN1qlFeatCtrl]
+          SQL++ feature control.
           This setting is provided for technical support only.
 
-          The {n1ql-feat-ctrl}[node-level] `n1ql-feat-ctrl` setting specifies this property for a single node.
+          The [node-level][n1ql-feat-ctrl] `n1ql-feat-ctrl` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [n1ql-feat-ctrl]: #n1ql-feat-ctrl
+        x-desc-refs: |
+          [n1ql-feat-ctrl]: ../n1ql/n1ql-rest-api/admin.html#n1ql-feat-ctrl
       queryNumAtrs:
         type: integer
         format: int32
@@ -264,80 +323,115 @@ definitions:
         exclusiveMinimum: true
         default: 1024
         example: 512
+        x-desc-name: queryNumAtrs
         description: |
-          [[queryNumAtrs]]
-          Specifies the total number of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for all Query nodes in the cluster.
+          [#queryNumAtrs]
+          Specifies the total number of [active transaction records][additional-storage-use] for all Query nodes in the cluster.
 
-          The {numatrs-srv}[node-level] `numatrs` setting specifies this property for a single node.
+          The [node-level][numatrs-srv] `numatrs` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, there is a {numatrs_req}[request-level] `numatrs` parameter.
+          In addition, there is a [request-level][numatrs_req] `numatrs` parameter.
           If a request includes this parameter, it will be capped by the node-level `numatrs` setting.
+
+          [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
+          [numatrs-srv]: #numatrs-srv
+          [numatrs_req]: #numatrs_req
+        x-desc-refs: |
+          [numatrs-srv]: ../n1ql/n1ql-rest-api/admin.html#numatrs-srv
+          [numatrs_req]: ../n1ql/n1ql-rest-api/index.html#numatrs_req
       queryPipelineBatch:
         type: integer
         format: int32
         default: 16
         example: 64
+        x-desc-name: queryPipelineBatch
         description: |
-          [[queryPipelineBatch]]
+          [#queryPipelineBatch]
           Controls the number of items execution operators can batch for Fetch from the KV.
 
-          The {pipeline-batch-srv}[node-level] `pipeline-batch` setting specifies this property for a single node.
+          The [node-level][pipeline-batch-srv] `pipeline-batch` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {pipeline_batch_req}[request-level] `pipeline_batch` parameter specifies this property per request.
+          In addition, the [request-level][pipeline_batch_req] `pipeline_batch` parameter specifies this property per request.
           The minimum of that and the node-level `pipeline-batch` setting is applied.
+
+          [pipeline-batch-srv]: #pipeline-batch-srv
+          [pipeline_batch_req]: #pipeline_batch_req
+        x-desc-refs: |
+          [pipeline-batch-srv]: ../n1ql/n1ql-rest-api/admin.html#pipeline-batch-srv
+          [pipeline_batch_req]: ../n1ql/n1ql-rest-api/index.html#pipeline_batch_req
       queryPipelineCap:
         type: integer
         format: int32
         default: 512
         example: 1024
+        x-desc-name: queryPipelineCap
         description: |
-          [[queryPipelineCap]]
+          [#queryPipelineCap]
           Maximum number of items each execution operator can buffer between various operators.
 
-          The {pipeline-cap-srv}[node-level] `pipeline-cap` setting specifies this property for a single node.
+          The [node-level][pipeline-cap-srv] `pipeline-cap` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {pipeline_cap_req}[request-level] `pipeline_cap` parameter specifies this property per request.
+          In addition, the [request-level][pipeline_cap_req] `pipeline_cap` parameter specifies this property per request.
           The minimum of that and the node-level `pipeline-cap` setting is applied.
+
+          [pipeline-cap-srv]: #pipeline-cap-srv
+          [pipeline_cap_req]: #pipeline_cap_req
+        x-desc-refs: |
+          [pipeline-cap-srv]: ../n1ql/n1ql-rest-api/admin.html#pipeline-cap-srv
+          [pipeline_cap_req]: ../n1ql/n1ql-rest-api/index.html#pipeline_cap_req
       queryPreparedLimit:
         type: integer
         format: int32
         default: 16384
         example: 65536
+        x-desc-name: queryPreparedLimit
         description: |
-          [[queryPreparedLimit]]
+          [#queryPreparedLimit]
           Maximum number of prepared statements in the cache.
           When this cache reaches the limit, the least recently used prepared statements will be discarded as new prepared statements are created.
 
-          The {prepared-limit-srv}[node-level] `prepared-limit` setting specifies this property for a single node.
+          The [node-level][prepared-limit] `prepared-limit` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          [prepared-limit]: #prepared-limit
+        x-desc-refs: |
+          [prepared-limit]: ../n1ql/n1ql-rest-api/admin.html#prepared-limit
       queryScanCap:
         type: integer
         format: int32
         default: 512
         example: 1024
+        x-desc-name: queryScanCap
         description: |
-          [[queryScanCap]]
+          [#queryScanCap]
           Maximum buffered channel size between the indexer client and the query service for index scans.
           This parameter controls when to use scan backfill.
 
           Use `0` or a negative number to disable.
           Smaller values reduce GC, while larger values reduce indexer backfill.
 
-          The {scan-cap-srv}[node-level] `scan-cap` setting specifies this property for a single node.
+          The [node-level][scan-cap-srv] `scan-cap` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {scan_cap_req}[request-level] `scan_cap` parameter specifies this property per request.
+          In addition, the [request-level][scan_cap_req] `scan_cap` parameter specifies this property per request.
           The minimum of that and the node-level `scan-cap` setting is applied.
+
+          [scan-cap-srv]: #scan-cap-srv
+          [scan_cap_req]: #scan_cap_req
+        x-desc-refs: |
+          [scan-cap-srv]: ../n1ql/n1ql-rest-api/admin.html#scan-cap-srv
+          [scan_cap_req]: ../n1ql/n1ql-rest-api/index.html#scan_cap_req
       queryTimeout:
         type: integer
         format: int64
         default: 0
         example: 500000000
+        x-desc-name: queryTimeout
         description: |
-          [[queryTimeout]]
+          [#queryTimeout]
           Maximum time to spend on the request before timing out (ns).
 
           The value for this setting is an integer, representing a duration in nanoseconds.
@@ -346,20 +440,27 @@ definitions:
           Specify `0` (the default value) or a negative integer to disable.
           When disabled, no timeout is applied and the request runs for however long it takes.
 
-          The {timeout-srv}[node-level] `timeout` setting specifies this property for a single node.
+          The [node-level][timeout-srv] `timeout` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {timeout_req}[request-level] `timeout` parameter specifies this property per request.
+          In addition, the [request-level][timeout_req] `timeout` parameter specifies this property per request.
           The minimum of that and the node-level `timeout` setting is applied.
+
+          [timeout-srv]: #timeout-srv
+          [timeout_req]: #timeout_req
+        x-desc-refs: |
+          [timeout-srv]: ../n1ql/n1ql-rest-api/admin.html#timeout-srv
+          [timeout_req]: ../n1ql/n1ql-rest-api/index.html#timeout_req
       queryTxTimeout:
         type: string
         format: duration
         default: "0ms"
         example: "0.5s"
+        x-desc-name: queryTxTimeout
         description: |
-          [[queryTxTimeout]]
+          [#queryTxTimeout]
           Maximum time to spend on a transaction before timing out.
-          This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the {tximplicit}[tximplicit] parameter is set.
+          This setting only applies to requests containing the `BEGIN TRANSACTION` statement, or to requests where the [tximplicit][tximplicit] parameter is set.
           For all other requests, it is ignored.
 
           The value for this setting is a string.
@@ -376,29 +477,39 @@ definitions:
           Specify `0ms` (the default value) to disable.
           When disabled, no timeout is applied and the transaction runs for however long it takes.
 
-          The {txtimeout-srv}[node-level] `txtimeout` setting specifies this property for a single node.
+          The [node-level][txtimeout-srv] `txtimeout` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, there is a {txtimeout_req}[request-level] `txtimeout` parameter.
+          In addition, there is a [request-level][txtimeout_req] `txtimeout` parameter.
           If a request includes this parameter, it will be capped by the node-level `txtimeout` setting.
+
+          [tximplicit]: #tximplicit
+          [txtimeout-srv]: #txtimeout-srv
+          [txtimeout_req]: #txtimeout_req
+        x-desc-refs: |
+          [tximplicit]: ../n1ql/n1ql-rest-api/index.html#tximplicit
+          [txtimeout-srv]: ../n1ql/n1ql-rest-api/admin.html#txtimeout-srv
+          [txtimeout_req]: ../n1ql/n1ql-rest-api/index.html#txtimeout_req
       queryTmpSpaceDir:
         type: string
         example: "/opt/couchbase/var/lib/couchbase/tmp"
+        x-desc-name: queryTmpSpaceDir
         description: |
-          [[queryTmpSpaceDir]]
+          [#queryTmpSpaceDir]
           The path to which the indexer writes temporary backfill files, to store any transient data during query processing.
 
           The specified path must already exist.
           Only absolute paths are allowed.
 
-          The default path is [.file]`var/lib/couchbase/tmp` within the Couchbase Server installation directory.
+          The default path is `var/lib/couchbase/tmp` within the Couchbase Server installation directory.
       queryTmpSpaceSize:
         type: integer
         format: int32
         default: 5120
         example: 2048
+        x-desc-name: queryTmpSpaceSize
         description: |
-          [[queryTmpSpaceSize]]
+          [#queryTmpSpaceSize]
           The maximum size of temporary backfill files (MB).
 
           Setting the size to `0` disables backfill.
@@ -409,18 +520,26 @@ definitions:
         type: boolean
         default: true
         example: false
+        x-desc-name: queryUseCBO
         description: |
-          [[queryUseCBO]]
+          [#queryUseCBO]
           Specifies whether the cost-based optimizer is enabled.
 
-          The {use-cbo-srv}[node-level] `use-cbo` setting specifies this property for a single node.
+          The [node-level][use-cbo-srv] `use-cbo` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
-          In addition, the {use_cbo_req}[request-level] `use_cbo` parameter specifies this property per request.
+          In addition, the [request-level][use_cbo_req] `use_cbo` parameter specifies this property per request.
           If a request does not include this parameter, the node-level setting is used, which defaults to `true`.
+
+          [use-cbo-srv]: #use-cbo-srv
+          [use_cbo_req]: #use_cbo_req
+        x-desc-refs: |
+          [use-cbo-srv]: ../n1ql/n1ql-rest-api/admin.html#use-cbo-srv
+          [use_cbo_req]: ../n1ql/n1ql-rest-api/index.html#use_cbo_req
       queryCurlWhitelist:
+        x-desc-name: queryCurlWhitelist
         description: |
-          [[queryCurlWhitelist]]
+          [#queryCurlWhitelist]
           An object which determines which URLs may be accessed by the `CURL()` function.
         $ref: "#/definitions/Access"
 
@@ -435,7 +554,7 @@ definitions:
         description: |
           Defines whether the user has access to all URLs, or only URLs specified by the access list.
 
-          This field set must be set to `false` to enable the [.param]`allowed_urls` and [.param]`disallowed_urls` fields.
+          This field set must be set to `false` to enable the `allowed_urls` and `disallowed_urls` fields.
 
           Setting this field to `true` enables access to all endpoints.
       allowed_urls:
@@ -445,8 +564,8 @@ definitions:
           Each URL is a prefix match.
           The CURL() function will allow any URL that starts with this value.
 
-          For example, if you wish to allow access to all Google APIs, add the URL `+++https://maps.googleapis.com+++` to the array.
-          To allow complete access to `localhost`, use `+++http://localhost+++`.
+          For example, if you wish to allow access to all Google APIs, add the URL https://maps.googleapis.com to the array.
+          To allow complete access to `localhost`, use http://localhost.
 
           Note that each URL must include the port, protocol, and all other components of the URL.
         default: []
@@ -459,7 +578,7 @@ definitions:
           Each URL is a prefix match.
           The CURL() function will disallow any URL that starts with this value.
 
-          If both [.param]`allowed_urls` and [.param]`disallowed_urls` fields are populated, the [.param]`disallowed_urls` field takes precedence over [.param]`allowed_urls`.
+          If both `allowed_urls` and `disallowed_urls` fields are populated, the `disallowed_urls` field takes precedence over `allowed_urls`.
 
           Note that each URL must include the port, protocol, and all other components of the URL.
         default: []

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -536,6 +536,39 @@ definitions:
         x-desc-refs: |
           [use-cbo-srv]: ../n1ql/n1ql-rest-api/admin.html#use-cbo-srv
           [use_cbo_req]: ../n1ql/n1ql-rest-api/index.html#use_cbo_req
+      queryUseReplica:
+        type: string
+        default: unset
+        enum: ["off","on","unset"]
+        example: on
+        x-desc-name: queryUseReplica
+        description: |
+          [#queryUseReplica]
+          Specifies whether a query can fetch data from a replica vBucket if active vBuckets are inaccessible.
+          The possible values are:
+
+          * `off` &mdash; read from replica is disabled for all queries and cannot be overridden at request level.
+
+          * `on` &mdash; read from replica is enabled for all queries, but can be disabled at request level.
+
+          * `unset` &mdash; read from replica is enabled or disabled at request level.
+
+          The [node-level][use-replica-srv] `use-replica` setting specifies this property for a single node.
+          When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
+
+          In addition, the [request-level][use_replica_req] `use_replica` parameter specifies this property per request.
+          If a request does not include this parameter, or if the request-level parameter is `unset`, the node-level setting is used.
+          If the request-level parameter and the node-level setting are both `unset`, read from replica is disabled for that request.
+
+          WARNING: Do not enable read from replica when you require consistent results.
+
+          SELECT queries within a transaction cannot read from replica.
+
+          [use-replica-srv]: #use-replica-srv
+          [use_replica_req]: #use_replica_req
+        x-desc-refs: |
+          [use-replica-srv]: ../n1ql/n1ql-rest-api/admin.html#use-replica-srv
+          [use_replica_req]: ../n1ql/n1ql-rest-api/index.html#use_replica_req
       queryCurlWhitelist:
         x-desc-name: queryCurlWhitelist
         description: |

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -560,9 +560,13 @@ definitions:
           If a request does not include this parameter, or if the request-level parameter is `unset`, the node-level setting is used.
           If the request-level parameter and the node-level setting are both `unset`, read from replica is disabled for that request.
 
-          WARNING: Do not enable read from replica when you require consistent results.
+          Do not enable read from replica when you require consistent results.
+          Only SELECT queries that are not within a transaction can read from replica.
 
-          SELECT queries within a transaction cannot read from replica.
+          Reading from replica is only possible if the cluster uses Couchbase Server 7.6.0 or later.
+
+          Note that KV range scans cannot currently be started on a replica vBucket.
+          If a query uses sequential scan and a data node becomes unavailable, the query might return an error, even if read from replica is enabled for the request.
 
           [use-replica-srv]: #use-replica-srv
           [use_replica_req]: #use_replica_req


### PR DESCRIPTION
Docs issue: DOC-10867

Added read replica parameters to Query Settings, Query Admin, and Query Service REST APIs. Also migrated the spec markup language from AsciiDoc to Markdown for future compatibility with Redocly.

Docs preview:

* [Query Settings REST API](https://ia.docs-test.couchbase.com/server/current/rest-api/rest-cluster-query-settings.html#queryUseReplica)
* [Query Admin REST API](https://ia.docs-test.couchbase.com/server/current/n1ql/n1ql-rest-api/admin.html#use-replica-srv)
* [Query Service REST API](https://ia.docs-test.couchbase.com/server/current/n1ql/n1ql-rest-api/index.html#use_replica_req)
* [Login details](https://couchbasecloud.atlassian.net/l/cp/2GtKM5Pr) &mdash; see IA Build

Linked pull requests:

* Settings and Parameters: https://github.com/couchbase/docs-server/pull/3401