### PR TITLE
DOC-11436: Document new Query service settings

### DIFF
--- a/docs/modules/rest-api/examples/query-settings-post-settings.jsonc
+++ b/docs/modules/rest-api/examples/query-settings-post-settings.jsonc
@@ -15,7 +15,6 @@
   "queryCompletedThreshold": 1000,
   "queryLogLevel": "info",
   "queryMaxParallelism": 1,
-  "queryN1QLFeatCtrl": 76,
   "queryTxTimeout": "0ms",
   "queryMemoryQuota": 0,
   "queryUseCBO": true,
@@ -23,11 +22,15 @@
   "queryCleanupLostAttempts": true,
   "queryCleanupWindow": "60s",
   "queryNumAtrs": 1024,
+  "queryNodeQuota": 0,
+  "queryUseReplica": "unset",
+  "queryNodeQuotaValPercent": 67,
+  "queryNumCpus": 0,
+  "queryCompletedMaxPlanSize": 262144,
+  "queryN1QLFeatCtrl": 76,
 // tag::access[]
   "queryCurlWhitelist": {
-    "all_access": false,
-    "allowed_urls": [],
-    "disallowed_urls": []
+    "all_access": false
   }
 }
 // end::access[]

--- a/docs/modules/rest-api/partials/query-settings/paths.adoc
+++ b/docs/modules/rest-api/partials/query-settings/paths.adoc
@@ -76,7 +76,6 @@ http://localhost:8091/settings/querySettings
   "queryCompletedThreshold": 1000,
   "queryLogLevel": "info",
   "queryMaxParallelism": 1,
-  "queryN1QLFeatCtrl": 76,
   "queryTxTimeout": "0ms",
   "queryMemoryQuota": 0,
   "queryUseCBO": true,
@@ -84,10 +83,14 @@ http://localhost:8091/settings/querySettings
   "queryCleanupLostAttempts": true,
   "queryCleanupWindow": "60s",
   "queryNumAtrs": 1024,
+  "queryNodeQuota": 0,
+  "queryUseReplica": "unset",
+  "queryNodeQuotaValPercent": 67,
+  "queryNumCpus": 0,
+  "queryCompletedMaxPlanSize": 262144,
+  "queryN1QLFeatCtrl": 76,
   "queryCurlWhitelist": {
-    "all_access": false,
-    "allowed_urls": [],
-    "disallowed_urls": []
+    "all_access": false
   }
 }
 ----

--- a/src/query-settings/extensions/spring/get_settings/http-response.adoc
+++ b/src/query-settings/extensions/spring/get_settings/http-response.adoc
@@ -15,7 +15,6 @@
   "queryCompletedThreshold": 1000,
   "queryLogLevel": "info",
   "queryMaxParallelism": 1,
-  "queryN1QLFeatCtrl": 76,
   "queryTxTimeout": "0ms",
   "queryMemoryQuota": 0,
   "queryUseCBO": true,
@@ -23,10 +22,14 @@
   "queryCleanupLostAttempts": true,
   "queryCleanupWindow": "60s",
   "queryNumAtrs": 1024,
+  "queryNodeQuota": 0,
+  "queryUseReplica": "unset",
+  "queryNodeQuotaValPercent": 67,
+  "queryNumCpus": 0,
+  "queryCompletedMaxPlanSize": 262144,
+  "queryN1QLFeatCtrl": 76,
   "queryCurlWhitelist": {
-    "all_access": false,
-    "allowed_urls": [],
-    "disallowed_urls": []
+    "all_access": false
   }
 }
 ----


### PR DESCRIPTION
Docs issue: DOC-11436

Adds updated examples for the Query Settings REST API.

Draft documentation: [Query Settings REST API](https://preview.docs-test.couchbase.com/DOC-11945/server/current/rest-api/rest-cluster-query-settings.html)

Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

Updates previous pull request:

* https://github.com/couchbase/docs-server/pull/3472