### PR TITLE
DOC-10865: Migrate settings reference to docs-devex

### DIFF
--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/paths.adoc
@@ -897,7 +897,7 @@ GET /admin/settings
 Returns node-level query settings.
 
 
-NOTE: Refer to xref:settings:query-settings.adoc[] for more information.
+NOTE: Refer to xref:n1ql:n1ql-manage/query-settings.adoc[] for more information.
 
 
 ===== Responses
@@ -929,7 +929,7 @@ POST /admin/settings
 Updates node-level query settings.
 
 
-NOTE: Refer to xref:settings:query-settings.adoc[] for more information.
+NOTE: Refer to xref:n1ql:n1ql-manage/query-settings.adoc[] for more information.
 
 
 ===== Parameters

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
@@ -67,7 +67,7 @@ Applicable if the statement or prepared statement contains 1 or more positional 
 
 The value is an array of JSON values, one for each positional parameter in the statement.
 
-Refer to link:/server/7.6/settings/query-settings.html#section_srh_tlm_n1b[Named Parameters and Positional Parameters] for details. +
+Refer to link:/server/7.6/n1ql/n1ql-manage/query-settings.html#section_srh_tlm_n1b[Named Parameters and Positional Parameters] for details. +
 **Example** : `[ "LAX", 6 ]`|< object > array
 |**atrcollection** +
 __optional__|[#atrcollection_req]
@@ -377,7 +377,7 @@ For multi-statement requests, the default behavior is RYOW within each request.
 If you want to disable RYOW within a request, add a separate `request_consistency` parameter that can be set to `not_bounded`.
 
 If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the <<tximplicit,tximplicit>> parameter set to `true`, then this parameter sets the transactional scan consistency.
-Refer to link:/server/7.6/settings/query-settings.html#transactional-scan-consistency[Transactional Scan Consistency] for details. +
+Refer to link:/server/7.6/n1ql/n1ql-manage/query-settings.html#transactional-scan-consistency[Transactional Scan Consistency] for details. +
 **Default** : `"not_bounded"` +
 **Example** : `"at_plus"`|enum (not_bounded, at_plus, request_plus, statement_plus)
 |**scan_vector** +
@@ -613,7 +613,7 @@ This must start with an alpha character, followed by one or more alphanumeric ch
 
 The value of the named parameter can be any JSON value.
 
-Refer to link:/server/7.6/settings/query-settings.html#section_srh_tlm_n1b[Named Parameters and Positional Parameters] for details.|string (any JSON value)
+Refer to link:/server/7.6/n1ql/n1ql-manage/query-settings.html#section_srh_tlm_n1b[Named Parameters and Positional Parameters] for details.|string (any JSON value)
 |===
 
 

--- a/src/admin/asciidoc/extensions/paths/get_settings/operation-description-after.adoc
+++ b/src/admin/asciidoc/extensions/paths/get_settings/operation-description-after.adoc
@@ -1,1 +1,1 @@
-NOTE: Refer to xref:settings:query-settings.adoc[] for more information.
+NOTE: Refer to xref:n1ql:n1ql-manage/query-settings.adoc[] for more information.

--- a/src/admin/asciidoc/extensions/paths/post_settings/operation-description-after.adoc
+++ b/src/admin/asciidoc/extensions/paths/post_settings/operation-description-after.adoc
@@ -1,1 +1,1 @@
-NOTE: Refer to xref:settings:query-settings.adoc[] for more information.
+NOTE: Refer to xref:n1ql:n1ql-manage/query-settings.adoc[] for more information.

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -192,7 +192,7 @@ definitions:
 
           Refer to [Named Parameters and Positional Parameters][section_srh_tlm_n1b] for details.
 
-          [section_srh_tlm_n1b]: /server/7.6/settings/query-settings.html#section_srh_tlm_n1b
+          [section_srh_tlm_n1b]: /server/7.6/n1ql/n1ql-manage/query-settings.html#section_srh_tlm_n1b
         example:
           - LAX
           - 6
@@ -662,7 +662,7 @@ definitions:
           If the request contains a `BEGIN TRANSACTION` statement, or a DML statement with the [tximplicit](#tximplicit) parameter set to `true`, then this parameter sets the transactional scan consistency.
           Refer to [Transactional Scan Consistency][transactional-scan-consistency] for details.
 
-          [transactional-scan-consistency]: /server/7.6/settings/query-settings.html#transactional-scan-consistency
+          [transactional-scan-consistency]: /server/7.6/n1ql/n1ql-manage/query-settings.html#transactional-scan-consistency
         enum: ["not_bounded", "at_plus", "request_plus", "statement_plus"]
         default: not_bounded
         example: at_plus
@@ -984,7 +984,7 @@ definitions:
 
           Refer to [Named Parameters and Positional Parameters][section_srh_tlm_n1b] for details.
 
-          [section_srh_tlm_n1b]: /server/7.6/settings/query-settings.html#section_srh_tlm_n1b
+          [section_srh_tlm_n1b]: /server/7.6/n1ql/n1ql-manage/query-settings.html#section_srh_tlm_n1b
 
   Credentials:
     type: object


### PR DESCRIPTION
Docs issue: DOC-10865

This linked PRs  the `query-settings` page (and its associated example files) from the docs-server repo into the docs-devex repo, so that it can be shared with the Capella devex documentation. Because these PRs migrate individual documents, rather than a whole module, links to those documents must all be updated also. (Note that in the preview site, xrefs will work, but links won't &mdash; this is just an artifact of the preview docs site. They'll be fine on a site without a subdirectory.)

Preview: [Query Admin REST API](https://preview.docs-test.couchbase.com/DOC-10865/server/current/n1ql/n1ql-rest-api/admin.html)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

This must be merged at the same time as the following PRs:

* https://github.com/couchbaselabs/docs-devex/pull/195
* https://github.com/couchbase/docs-server/pull/3563