### PR TITLE
DOC-10865: Migrate settings reference to docs-devex

### DIFF
--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
@@ -76,10 +76,7 @@ The collection must be present.
 If not specified, the ATR is stored in the default collection in the default scope in the bucket containing the first mutated document within the transaction.
 
 The value must be a string in the form `&quot;bucket.scope.collection&quot;` or `&quot;namespace:bucket.scope.collection&quot;`.
-If any part of the path contains a special character, that part of the path must be delimited in backticks &grave;&grave;.
-
-The <<atrcollection-srv,node-level>> `atrcollection` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting. +
+If any part of the path contains a special character, that part of the path must be delimited in backticks &grave;&grave;. +
 **Example** : `"default:&grave;travel-sample&grave;.transaction.test"`|string
 |**auto_execute** +
 __optional__|[#auto_execute]
@@ -109,27 +106,8 @@ Specifies if there should be a controls section returned with the request result
 
 When set to `true`, the query response document includes a controls section with runtime information provided along with the request, such as positional and named parameters or settings.
 
-If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
-
-The <<controls-srv,node-level>> `controls` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting. +
+If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace. +
 **Example** : `true`|boolean
-|**creds** +
-__optional__|[#creds]
-Specifies the login credentials.
-The Query API supports two types of identity: local (or bucket) and admin.
-
-The format is an identity and password.
-You can specify credentials for multiple identities.
-
-If credentials are supplied in the request header, then HTTP Basic Authentication takes precedence and `creds` is ignored. +
-**Example** : `[ {
-  "user" : "local:bucket-name",
-  "pass" : "password"
-}, {
-  "user" : "admin:admin-name",
-  "pass" : "password"
-} ]`|< <<_credentials,Credentials>> > array
 |**durability_level** +
 __optional__|[#durability_level]
 The level of link:/server/7.6/learn/data/durability.html[durability] for mutations produced by the request.
@@ -145,7 +123,7 @@ Set the durability level to `&quot;none&quot;` or `&quot;&quot;` to specify no d
 **Example** : `"none"`|enum (&quot;&quot;, none, majority, majorityAndPersistActive, persistToMajority)
 |**encoded_plan** +
 __optional__|[#encoded_plan]
-In Couchbase Server 6.5 and later, this parameter is ignored and has no effect.
+In databases running Couchbase Server 6.5 and later, this parameter is ignored and has no effect.
 It is included for compatibility with previous versions of Couchbase Server.|string
 |**encoding** +
 __optional__|[#encoding]
@@ -186,16 +164,6 @@ When disabled, no timeout is applied and the KV operation runs for however long 
 __optional__|[#max_parallelism_req]
 Specifies the maximum parallelism for the query.
 
-The <<max-parallelism-srv,node-level>> `max-parallelism` setting specifies the ceiling for this parameter for a single node.
-If the request-level parameter is zero or negative, the parallelism for the query is set to the node-level setting.
-If the request-level parameter is greater than zero and less than the node-level setting, the request-level parameter overrides the node-level setting.
-If the request-level parameter is greater than the node-level setting, the parallelism for the query is set to the node-level setting.
-
-In addition, the <<queryMaxParallelism,cluster-level>> `queryMaxParallelism` setting specifies the ceiling for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
-
-To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
-
 The default value is the same as the number of partitions of the index selected for the query. +
 **Example** : `3`|integer (int32)
 |**memory_quota** +
@@ -210,14 +178,7 @@ processing a request. It does not take into account any other memory that might 
 process a request, such as the stack, the operators, or some intermediate values.
 
 Within a transaction, this setting enforces the memory quota for the transaction by tracking the
-delta table and the transaction log (approximately).
-
-The <<memory-quota-srv,node-level>> `memory-quota` setting specifies the ceiling for this parameter for a single node.
-If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.
-If the node-level setting is greater than zero, the request-level parameter is capped by the node-level setting.
-
-In addition, the <<queryMemoryQuota,cluster-level>> `queryMemoryQuota` setting specifies the ceiling for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
+delta table and the transaction log (approximately). +
 **Default** : `0` +
 **Example** : `4`|integer (int32)
 |**metrics** +
@@ -231,34 +192,16 @@ __optional__|Specifies the namespace to use. Currently, only the `default` names
 |**numatrs** +
 __optional__|[#numatrs_req]
 Specifies the total number of link:/server/7.6/learn/data/transactions.html#active-transaction-record-entries[active transaction records].
-Must be a positive integer.
-
-The <<numatrs-srv,node-level>> `numatrs` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting.
-
-In addition, the <<queryNumAtrs,cluster-level>> `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
+Must be a positive integer. +
 **Default** : `1024` +
 **Example** : `512`|integer (int32)
 |**pipeline_batch** +
 __optional__|[#pipeline_batch_req]
-Controls the number of items execution operators can batch for Fetch from the KV.
-
-The <<pipeline-batch-srv,node-level>> `pipeline-batch` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
-
-In addition, the <<queryPipelineBatch,cluster-level>> `queryPipelineBatch` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
+Controls the number of items execution operators can batch for Fetch from the KV. +
 **Example** : `64`|integer (int32)
 |**pipeline_cap** +
 __optional__|[#pipeline_cap_req]
-Maximum number of items each execution operator can buffer between various operators.
-
-The <<pipeline-cap-srv,node-level>> `pipeline-cap` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
-
-In addition, the <<queryPipelineCap,cluster-level>> `queryPipelineCap` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
+Maximum number of items each execution operator can buffer between various operators. +
 **Example** : `1024`|integer (int32)
 |**prepared** +
 __optional__|[#prepared]
@@ -283,10 +226,7 @@ Not supported for statements in a transaction. +
 **Example** : `true`|boolean
 |**pretty** +
 __optional__|[#pretty_req]
-Specifies the query results returned in pretty format.
-
-The <<pretty-srv,node-level>> `pretty` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting. +
+Specifies the query results returned in pretty format. +
 **Example** : `false`|boolean
 |**profile** +
 __optional__|[#profile_req]
@@ -303,10 +243,7 @@ Three phase times will be included in the `system:active_requests` and `system:c
 Besides the phase times, the profile section of the query response document will include a full query plan with timing and information about the number of processed documents at each phase.
 This information will be included in the `system:active_requests` and `system:completed_requests` keyspaces.
 
-If `profile` is not set as one of the above values, then the profile setting does not change.
-
-The <<profile-srv,node-level>> `profile` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting. +
+If `profile` is not set as one of the above values, then the profile setting does not change. +
 **Example** : `"phases"`|enum (off, phases, timings)
 |**query_context** +
 __optional__|[#query_context]
@@ -339,13 +276,7 @@ Maximum buffered channel size between the indexer client and the query service f
 This parameter controls when to use scan backfill.
 
 Use `0` or a negative number to disable.
-Smaller values reduce GC, while larger values reduce indexer backfill.
-
-The <<scan-cap-srv,node-level>> `scan-cap` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
-
-In addition, the <<queryScanCap,cluster-level>> `queryScanCap` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
+Smaller values reduce GC, while larger values reduce indexer backfill. +
 **Example** : `1024`|integer (int32)
 |**scan_consistency** +
 __optional__|[#scan_consistency]
@@ -474,14 +405,7 @@ Specify a duration of `0` or a negative duration to disable.
 When disabled, no timeout is applied and the request runs for however long it takes.
 
 If <<tximplicit,tximplicit>> or <<txid,txid>> is set, this parameter is ignored.
-The request inherits the remaining time of the transaction as timeout.
-
-The <<timeout-srv,node-level>> `timeout` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting.
-However, if the node-level setting is greater than 0, the timeout for the query is limited to the node-level setting.
-
-In addition, the <<queryTimeout,cluster-level>> `queryTimeout` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
+The request inherits the remaining time of the transaction as timeout. +
 **Example** : `"30m"`|string (duration)
 |**txdata** +
 __optional__|[#txdata]
@@ -539,29 +463,14 @@ Valid units are:
 Specify a duration of `0` to disable.
 When disabled, the request-level timeout is set to the default.
 
-The <<txtimeout-srv,node-level>> `txtimeout` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting.
-However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
-
-In addition, the <<queryTxTimeout,cluster-level>> `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
-
 The default is `&quot;15s&quot;` for cbq files or scripts, `&quot;2m&quot;` for interactive cbq sessions or redirected input. +
 **Example** : `"30m"`|string (duration)
 |**use_cbo** +
 __optional__|[#use_cbo_req]
-Specifies whether the cost-based optimizer is enabled.
-
-The <<use-cbo-srv,node-level>> `use-cbo` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting.
-
-In addition, the <<queryUseCBO,cluster-level>> `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
+Specifies whether the cost-based optimizer is enabled. +
 **Example** : `true`|boolean
 |**use_fts** +
 __optional__|[#use_fts]
-&blacktriangleright; https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
-
 Specifies that the query should use a full-text index.
 
 If the query contains a `USING FTS` hint, that takes priority over this parameter.
@@ -585,13 +494,6 @@ The possible values are:
 * `unset` &mdash; read from replica is specified by the node-level setting.
 If the node-level setting is also `unset`, read from replica is disabled for this request.
 
-The <<use-replica-srv,node-level>> `use-replica` setting specifies the default for this property for a single node.
-The request-level parameter usually overrides the node-level setting.
-However, when the node-level setting is `off`, the request-level parameter cannot enable the property.
-
-In addition, the <<queryUseReplica,cluster-level>> `queryUseReplica` setting specifies the default for this property for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
-
 Do not enable read from replica when you require consistent results.
 Only SELECT queries that are not within a transaction can read from replica.
 
@@ -609,7 +511,7 @@ Applicable if the statement or prepared statement contains 1 or more named param
 The name of this property consists of two parts:
 
 . The `$` character.
-This may be the `$` character or the `@` character in databases running Couchbase Server 7.6.0 and later.
+In databases running Couchbase Server 7.6.0 and later, this may be the `$` character or the `@` character.
 . An identifier that specifies the name of the parameter.
 This must start with an alpha character, followed by one or more alphanumeric characters.
 
@@ -620,25 +522,6 @@ Refer to link:/cloud/n1ql/n1ql-manage/query-settings.html#section_srh_tlm_n1b[Na
 
 
 // end::settings[]
-
-
-[[_credentials]]
-=== Credentials
-
-// tag::credentials[]
-
-
-[options="header", cols=".^3a,.^11a,.^4a"]
-|===
-|Name|Description|Schema
-|**user** +
-__optional__|An identity for authentication. Note that bucket names may be prefixed with `local:`, and admin names may be prefixed with `admin:`.|string
-|**pass** +
-__optional__|A password for authentication.|string
-|===
-
-
-// end::credentials[]
 
 
 [[_response_body]]

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/paths.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/paths.adoc
@@ -71,7 +71,6 @@ This section describes the response HTTP status codes.
 |===
 |Type|Name
 |**basic**|**<<_header,Header>>**
-|**apiKey**|**<<_parameter,Parameter>>**
 |===
 
 
@@ -165,7 +164,6 @@ This section describes the response HTTP status codes.
 |===
 |Type|Name
 |**basic**|**<<_header,Header>>**
-|**apiKey**|**<<_parameter,Parameter>>**
 |===
 
 

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/security.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/security.adoc
@@ -19,16 +19,6 @@ This method can only be used to provide a single credential.
 __Type__ : basic
 
 
-[[_parameter]]
-=== Parameter
-Specify user names and passwords via the `creds` request parameter. This is the only method that can provide multiple credentials for a request.
-
-[%hardbreaks]
-__Type__ : apiKey
-__Name__ : creds
-__In__ : QUERY
-
-
 ### RBAC Role
 // Use Markdown-style headings to avoid offset
 

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -374,20 +374,20 @@ definitions:
           [#max_parallelism_req]
           Specifies the maximum parallelism for the query.
 
+          The default value is the same as the number of partitions of the index selected for the query.
+
 #         The [node-level][max-parallelism-srv] `max-parallelism` setting specifies the ceiling for this parameter for a single node.
 #         If the request-level parameter is zero or negative, the parallelism for the query is set to the node-level setting.
 #         If the request-level parameter is greater than zero and less than the node-level setting, the request-level parameter overrides the node-level setting.
 #         If the request-level parameter is greater than the node-level setting, the parallelism for the query is set to the node-level setting.
 
-          In addition, the [cluster-level][queryMaxParallelism] `queryMaxParallelism` setting specifies the ceiling for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+#         In addition, the [cluster-level][queryMaxParallelism] `queryMaxParallelism` setting specifies the ceiling for this parameter for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-          To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
-
-          The default value is the same as the number of partitions of the index selected for the query.
+#         To enable queries to run in parallel, you must specify the cluster-level `queryMaxParallelism` parameter, or specify the node-level `max-parallelism` parameter on all Query nodes.
 
 #         [max-parallelism-srv]: #max-parallelism-srv
-          [queryMaxParallelism]: #queryMaxParallelism
+#         [queryMaxParallelism]: #queryMaxParallelism
         x-desc-refs: |
           [max-parallelism-srv]: admin.html#max-parallelism-srv
           [queryMaxParallelism]: ../../rest-api/rest-cluster-query-settings.html#queryMaxParallelism
@@ -414,11 +414,11 @@ definitions:
 #         If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.
 #         If the node-level setting is greater than zero, the request-level parameter is capped by the node-level setting.
 
-          In addition, the [cluster-level][queryMemoryQuota] `queryMemoryQuota` setting specifies the ceiling for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+#         In addition, the [cluster-level][queryMemoryQuota] `queryMemoryQuota` setting specifies the ceiling for this parameter for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 #         [memory-quota-srv]: #memory-quota-srv
-          [queryMemoryQuota]: #queryMemoryQuota
+#         [queryMemoryQuota]: #queryMemoryQuota
         x-desc-refs: |
           [memory-quota-srv]: admin.html#memory-quota-srv
           [queryMemoryQuota]: ../../rest-api/rest-cluster-query-settings.html#queryMemoryQuota
@@ -453,11 +453,11 @@ definitions:
 #         The [node-level][numatrs-srv] `numatrs` setting specifies the default for this parameter for a single node.
 #         The request-level parameter overrides the node-level setting.
 
-          In addition, the [cluster-level][queryNumAtrs] `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+#         In addition, the [cluster-level][queryNumAtrs] `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 #         [numatrs-srv]: #numatrs-srv
-          [queryNumAtrs]: #queryNumAtrs
+#         [queryNumAtrs]: #queryNumAtrs
         x-desc-refs: |
           [numatrs-srv]: admin.html#numatrs-srv
           [queryNumAtrs]: ../../rest-api/rest-cluster-query-settings.html#queryNumAtrs
@@ -474,11 +474,11 @@ definitions:
 #         The [node-level][pipeline-batch-srv] `pipeline-batch` setting specifies the default for this parameter for a single node.
 #         The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
-          In addition, the [cluster-level][queryPipelineBatch] `queryPipelineBatch` setting specifies the default for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+#         In addition, the [cluster-level][queryPipelineBatch] `queryPipelineBatch` setting specifies the default for this parameter for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 #         [pipeline-batch-srv]: #pipeline-batch-srv
-          [queryPipelineBatch]: #queryPipelineBatch
+#         [queryPipelineBatch]: #queryPipelineBatch
         x-desc-refs: |
           [pipeline-batch-srv]: admin.html#pipeline-batch-srv
           [queryPipelineBatch]: ../../rest-api/rest-cluster-query-settings.html#queryPipelineBatch
@@ -494,11 +494,11 @@ definitions:
 #         The [node-level][pipeline-cap-srv] `pipeline-cap` setting specifies the default for this parameter for a single node.
 #         The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
-          In addition, the [cluster-level][queryPipelineCap] `queryPipelineCap` setting specifies the default for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+#         In addition, the [cluster-level][queryPipelineCap] `queryPipelineCap` setting specifies the default for this parameter for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 #         [pipeline-cap-srv]: #pipeline-cap-srv
-          [queryPipelineCap]: #queryPipelineCap
+#         [queryPipelineCap]: #queryPipelineCap
         x-desc-refs: |
           [pipeline-cap-srv]: admin.html#pipeline-cap-srv
           [queryPipelineCap]: ../../rest-api/rest-cluster-query-settings.html#queryPipelineCap
@@ -620,11 +620,11 @@ definitions:
 #         The [node-level][scan-cap-srv] `scan-cap` setting specifies the default for this parameter for a single node.
 #         The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
-          In addition, the [cluster-level][queryScanCap] `queryScanCap` setting specifies the default for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+#         In addition, the [cluster-level][queryScanCap] `queryScanCap` setting specifies the default for this parameter for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 #         [scan-cap-srv]: #scan-cap-srv
-          [queryScanCap]: #queryScanCap
+#         [queryScanCap]: #queryScanCap
         x-desc-refs: |
           [scan-cap-srv]: admin.html#scan-cap-srv
           [queryScanCap]: ../../rest-api/rest-cluster-query-settings.html#queryScanCap
@@ -793,11 +793,11 @@ definitions:
 #         The request-level parameter overrides the node-level setting.
 #         However, if the node-level setting is greater than 0, the timeout for the query is limited to the node-level setting.
 
-          In addition, the [cluster-level][queryTimeout] `queryTimeout` setting specifies the default for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+#         In addition, the [cluster-level][queryTimeout] `queryTimeout` setting specifies the default for this parameter for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 #         [timeout-srv]: #timeout-srv
-          [queryTimeout]: #queryTimeout
+#         [queryTimeout]: #queryTimeout
         x-desc-refs: |
           [timeout-srv]: admin.html#timeout-srv
           [queryTimeout]: ../../rest-api/rest-cluster-query-settings.html#queryTimeout
@@ -876,17 +876,17 @@ definitions:
           Specify a duration of `0` to disable.
           When disabled, the request-level timeout is set to the default.
 
+          The default is `"15s"` for cbq files or scripts, `"2m"` for interactive cbq sessions or redirected input.
+
 #         The [node-level][txtimeout-srv] `txtimeout` setting specifies the default for this parameter for a single node.
 #         The request-level parameter overrides the node-level setting.
 #         However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
 
-          In addition, the [cluster-level][queryTxTimeout] `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
-
-          The default is `"15s"` for cbq files or scripts, `"2m"` for interactive cbq sessions or redirected input.
+#         In addition, the [cluster-level][queryTxTimeout] `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 #         [txtimeout-srv]: #txtimeout-srv
-          [queryTxTimeout]: #queryTxTimeout
+#         [queryTxTimeout]: #queryTxTimeout
         x-desc-refs: |
           [txtimeout-srv]: admin.html#txtimeout-srv
           [queryTxTimeout]: ../../rest-api/rest-cluster-query-settings.html#queryTxTimeout
@@ -901,11 +901,11 @@ definitions:
 #         The [node-level][use-cbo-srv] `use-cbo` setting specifies the default for this parameter for a single node.
 #         The request-level parameter overrides the node-level setting.
 
-          In addition, the [cluster-level][queryUseCBO] `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+#         In addition, the [cluster-level][queryUseCBO] `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
 #         [use-cbo-srv]: #use-cbo-srv
-          [queryUseCBO]: #queryUseCBO
+#         [queryUseCBO]: #queryUseCBO
         x-desc-refs: |
           [use-cbo-srv]: admin.html#use-cbo-srv
           [queryUseCBO]: ../../rest-api/rest-cluster-query-settings.html#queryUseCBO
@@ -948,13 +948,6 @@ definitions:
           * `unset` &mdash; read from replica is specified by the node-level setting.
           If the node-level setting is also `unset`, read from replica is disabled for this request.
 
-#         The [node-level][use-replica-srv] `use-replica` setting specifies the default for this property for a single node.
-#         The request-level parameter usually overrides the node-level setting.
-#         However, when the node-level setting is `off`, the request-level parameter cannot enable the property.
-
-          In addition, the [cluster-level][queryUseReplica] `queryUseReplica` setting specifies the default for this property for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
-
           Do not enable read from replica when you require consistent results.
           Only SELECT queries that are not within a transaction can read from replica.
 
@@ -963,8 +956,15 @@ definitions:
           Note that KV range scans cannot currently be started on a replica vBucket.
           If a query uses sequential scan and a data node becomes unavailable, the query might return an error, even if read from replica is enabled for the request.
 
+#         The [node-level][use-replica-srv] `use-replica` setting specifies the default for this property for a single node.
+#         The request-level parameter usually overrides the node-level setting.
+#         However, when the node-level setting is `off`, the request-level parameter cannot enable the property.
+
+#         In addition, the [cluster-level][queryUseReplica] `queryUseReplica` setting specifies the default for this property for the whole cluster.
+#         When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
+
 #         [use-replica-srv]: #use-replica-srv
-          [queryUseReplica]: #queryUseReplica
+#         [queryUseReplica]: #queryUseReplica
         x-desc-refs: |
           [use-replica-srv]: admin.html#use-replica-srv
           [queryUseReplica]: ../../rest-api/rest-cluster-query-settings.html#queryUseReplica

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -37,7 +37,7 @@ paths:
             $ref: "#/definitions/Request Parameters"
       security:
         - Header: []
-        - Parameter: []
+#       - Parameter: []
       responses:
         "200":
           $ref: '#/responses/OK'
@@ -73,7 +73,7 @@ paths:
         This endpoint is intended for situations where use of the `POST` method is restricted.
       security:
         - Header: []
-        - Parameter: []
+#       - Parameter: []
       responses:
         "200":
           $ref: '#/responses/OK'
@@ -269,25 +269,25 @@ definitions:
         x-desc-refs: |
           [controls-srv]: admin.html#controls-srv
         example: true
-      creds:
-        type: array
-        items:
-          $ref: "#/definitions/Credentials"
-        x-desc-name: creds
-        description: |
-          [#creds]
-          Specifies the login credentials.
-          The Query API supports two types of identity: local (or bucket) and admin.
+#     creds:
+#       type: array
+#       items:
+#         $ref: "#/definitions/Credentials"
+#       x-desc-name: creds
+#       description: |
+#         [#creds]
+#         Specifies the login credentials.
+#         The Query API supports two types of identity: local (or bucket) and admin.
 
-          The format is an identity and password.
-          You can specify credentials for multiple identities.
+#         The format is an identity and password.
+#         You can specify credentials for multiple identities.
 
-          If credentials are supplied in the request header, then HTTP Basic Authentication takes precedence and `creds` is ignored.
-        example:
-          - user: local:bucket-name
-            pass: password
-          - user: admin:admin-name
-            pass: password
+#         If credentials are supplied in the request header, then HTTP Basic Authentication takes precedence and `creds` is ignored.
+#       example:
+#         - user: local:bucket-name
+#           pass: password
+#         - user: admin:admin-name
+#           pass: password
       durability_level:
         type: string
         x-desc-name: durability_level
@@ -990,18 +990,18 @@ definitions:
 
           [section_srh_tlm_n1b]: /cloud/n1ql/n1ql-manage/query-settings.html#section_srh_tlm_n1b
 
-  Credentials:
-    type: object
-    title: Credentials
-    properties:
-      user:
-        type: string
-        description: >
-          An identity for authentication.
-          Note that bucket names may be prefixed with `local:`, and admin names may be prefixed with `admin:`.
-      pass:
-        type: string
-        description: A password for authentication.
+# Credentials:
+#   type: object
+#   title: Credentials
+#   properties:
+#     user:
+#       type: string
+#       description: >
+#         An identity for authentication.
+#         Note that bucket names may be prefixed with `local:`, and admin names may be prefixed with `admin:`.
+#     pass:
+#       type: string
+#       description: A password for authentication.
 
   Response Body:
     type: object
@@ -1185,10 +1185,10 @@ securityDefinitions:
       Specify a user name and password via HTTP headers.
       This method can only be used to provide a single credential.
 
-  Parameter:
-    type: apiKey
-    name: creds
-    in: query
-    description: >
-      Specify user names and passwords via the `creds` request parameter.
-      This is the only method that can provide multiple credentials for a request.
+# Parameter:
+#   type: apiKey
+#   name: creds
+#   in: query
+#   description: >
+#     Specify user names and passwords via the `creds` request parameter.
+#     This is the only method that can provide multiple credentials for a request.

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -319,7 +319,7 @@ definitions:
         x-desc-name: encoded_plan
         description: |
           [#encoded_plan]
-          In Couchbase Server 6.5 and later, this parameter is ignored and has no effect.
+          In databases running Couchbase Server 6.5 and later, this parameter is ignored and has no effect.
           It is included for compatibility with previous versions of Couchbase Server.
       encoding:
         type: string
@@ -915,8 +915,6 @@ definitions:
         x-desc-name: use_fts
         description: |
           [#use_fts]
-          &blacktriangleright; [ENTERPRISE EDITION](https://www.couchbase.com/products/editions)
-
           Specifies that the query should use a full-text index.
 
           If the query contains a `USING FTS` hint, that takes priority over this parameter.
@@ -980,7 +978,7 @@ definitions:
           The name of this property consists of two parts:
 
           1. The `$` character.
-              This may be the `$` character or the `@` character in databases running Couchbase Server 7.6.0 and later.
+              In databases running Couchbase Server 7.6.0 and later, this may be the `$` character or the `@` character.
           2. An identifier that specifies the name of the parameter.
               This must start with an alpha character, followed by one or more alphanumeric characters.
 

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -208,11 +208,12 @@ definitions:
           The value must be a string in the form `"bucket.scope.collection"` or `"namespace:bucket.scope.collection"`.
           If any part of the path contains a special character, that part of the path must be delimited in backticks &grave;&grave;.
 
-          The [node-level][atrcollection-srv] `atrcollection` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting.
-
           [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
-          [atrcollection-srv]: #atrcollection-srv
+
+#          The [node-level][atrcollection-srv] `atrcollection` setting specifies the default for this parameter for a single node.
+#          The request-level parameter overrides the node-level setting.
+
+#          [atrcollection-srv]: #atrcollection-srv
         x-desc-refs: |
           [atrcollection-srv]: admin.html#atrcollection-srv
         example: default:&grave;travel-sample&grave;.transaction.test
@@ -261,10 +262,10 @@ definitions:
 
           If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
 
-          The [node-level][controls-srv] `controls` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting.
+#         The [node-level][controls-srv] `controls` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting.
 
-          [controls-srv]: #controls-srv
+#         [controls-srv]: #controls-srv
         x-desc-refs: |
           [controls-srv]: admin.html#controls-srv
         example: true
@@ -373,10 +374,10 @@ definitions:
           [#max_parallelism_req]
           Specifies the maximum parallelism for the query.
 
-          The [node-level][max-parallelism-srv] `max-parallelism` setting specifies the ceiling for this parameter for a single node.
-          If the request-level parameter is zero or negative, the parallelism for the query is set to the node-level setting.
-          If the request-level parameter is greater than zero and less than the node-level setting, the request-level parameter overrides the node-level setting.
-          If the request-level parameter is greater than the node-level setting, the parallelism for the query is set to the node-level setting.
+#         The [node-level][max-parallelism-srv] `max-parallelism` setting specifies the ceiling for this parameter for a single node.
+#         If the request-level parameter is zero or negative, the parallelism for the query is set to the node-level setting.
+#         If the request-level parameter is greater than zero and less than the node-level setting, the request-level parameter overrides the node-level setting.
+#         If the request-level parameter is greater than the node-level setting, the parallelism for the query is set to the node-level setting.
 
           In addition, the [cluster-level][queryMaxParallelism] `queryMaxParallelism` setting specifies the ceiling for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
@@ -385,7 +386,7 @@ definitions:
 
           The default value is the same as the number of partitions of the index selected for the query.
 
-          [max-parallelism-srv]: #max-parallelism-srv
+#         [max-parallelism-srv]: #max-parallelism-srv
           [queryMaxParallelism]: #queryMaxParallelism
         x-desc-refs: |
           [max-parallelism-srv]: admin.html#max-parallelism-srv
@@ -409,14 +410,14 @@ definitions:
           Within a transaction, this setting enforces the memory quota for the transaction by tracking the
           delta table and the transaction log (approximately).
 
-          The [node-level][memory-quota-srv] `memory-quota` setting specifies the ceiling for this parameter for a single node.
-          If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.
-          If the node-level setting is greater than zero, the request-level parameter is capped by the node-level setting.
+#         The [node-level][memory-quota-srv] `memory-quota` setting specifies the ceiling for this parameter for a single node.
+#         If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.
+#         If the node-level setting is greater than zero, the request-level parameter is capped by the node-level setting.
 
           In addition, the [cluster-level][queryMemoryQuota] `queryMemoryQuota` setting specifies the ceiling for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-          [memory-quota-srv]: #memory-quota-srv
+#         [memory-quota-srv]: #memory-quota-srv
           [queryMemoryQuota]: #queryMemoryQuota
         x-desc-refs: |
           [memory-quota-srv]: admin.html#memory-quota-srv
@@ -447,14 +448,15 @@ definitions:
           Specifies the total number of [active transaction records][additional-storage-use].
           Must be a positive integer.
 
-          The [node-level][numatrs-srv] `numatrs` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting.
+          [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
+
+#         The [node-level][numatrs-srv] `numatrs` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting.
 
           In addition, the [cluster-level][queryNumAtrs] `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-          [additional-storage-use]: /server/7.6/learn/data/transactions.html#active-transaction-record-entries
-          [numatrs-srv]: #numatrs-srv
+#         [numatrs-srv]: #numatrs-srv
           [queryNumAtrs]: #queryNumAtrs
         x-desc-refs: |
           [numatrs-srv]: admin.html#numatrs-srv
@@ -469,13 +471,13 @@ definitions:
           [#pipeline_batch_req]
           Controls the number of items execution operators can batch for Fetch from the KV.
 
-          The [node-level][pipeline-batch-srv] `pipeline-batch` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
+#         The [node-level][pipeline-batch-srv] `pipeline-batch` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
           In addition, the [cluster-level][queryPipelineBatch] `queryPipelineBatch` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-          [pipeline-batch-srv]: #pipeline-batch-srv
+#         [pipeline-batch-srv]: #pipeline-batch-srv
           [queryPipelineBatch]: #queryPipelineBatch
         x-desc-refs: |
           [pipeline-batch-srv]: admin.html#pipeline-batch-srv
@@ -489,13 +491,13 @@ definitions:
           [#pipeline_cap_req]
           Maximum number of items each execution operator can buffer between various operators.
 
-          The [node-level][pipeline-cap-srv] `pipeline-cap` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
+#         The [node-level][pipeline-cap-srv] `pipeline-cap` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
           In addition, the [cluster-level][queryPipelineCap] `queryPipelineCap` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-          [pipeline-cap-srv]: #pipeline-cap-srv
+#         [pipeline-cap-srv]: #pipeline-cap-srv
           [queryPipelineCap]: #queryPipelineCap
         x-desc-refs: |
           [pipeline-cap-srv]: admin.html#pipeline-cap-srv
@@ -537,10 +539,10 @@ definitions:
           [#pretty_req]
           Specifies the query results returned in pretty format.
 
-          The [node-level][pretty-srv] `pretty` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting.
+#         The [node-level][pretty-srv] `pretty` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting.
 
-          [pretty-srv]: #pretty-srv
+#         [pretty-srv]: #pretty-srv
         x-desc-refs: |
           [pretty-srv]: admin.html#pretty-srv
         example: false
@@ -564,10 +566,10 @@ definitions:
 
           If `profile` is not set as one of the above values, then the profile setting does not change.
 
-          The [node-level][profile-srv] `profile` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting.
+#         The [node-level][profile-srv] `profile` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting.
 
-          [profile-srv]: #profile-srv
+#         [profile-srv]: #profile-srv
         x-desc-refs: |
           [profile-srv]: admin.html#profile-srv
         enum: ["off", "phases", "timings"]
@@ -615,13 +617,13 @@ definitions:
           Use `0` or a negative number to disable.
           Smaller values reduce GC, while larger values reduce indexer backfill.
 
-          The [node-level][scan-cap-srv] `scan-cap` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
+#         The [node-level][scan-cap-srv] `scan-cap` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
           In addition, the [cluster-level][queryScanCap] `queryScanCap` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-          [scan-cap-srv]: #scan-cap-srv
+#         [scan-cap-srv]: #scan-cap-srv
           [queryScanCap]: #queryScanCap
         x-desc-refs: |
           [scan-cap-srv]: admin.html#scan-cap-srv
@@ -787,14 +789,14 @@ definitions:
           If [tximplicit](#tximplicit) or [txid](#txid) is set, this parameter is ignored.
           The request inherits the remaining time of the transaction as timeout.
 
-          The [node-level][timeout-srv] `timeout` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting.
-          However, if the node-level setting is greater than 0, the timeout for the query is limited to the node-level setting.
+#         The [node-level][timeout-srv] `timeout` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting.
+#         However, if the node-level setting is greater than 0, the timeout for the query is limited to the node-level setting.
 
           In addition, the [cluster-level][queryTimeout] `queryTimeout` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-          [timeout-srv]: #timeout-srv
+#         [timeout-srv]: #timeout-srv
           [queryTimeout]: #queryTimeout
         x-desc-refs: |
           [timeout-srv]: admin.html#timeout-srv
@@ -874,16 +876,16 @@ definitions:
           Specify a duration of `0` to disable.
           When disabled, the request-level timeout is set to the default.
 
-          The [node-level][txtimeout-srv] `txtimeout` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting.
-          However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
+#         The [node-level][txtimeout-srv] `txtimeout` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting.
+#         However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
 
           In addition, the [cluster-level][queryTxTimeout] `queryTxTimeout` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
           The default is `"15s"` for cbq files or scripts, `"2m"` for interactive cbq sessions or redirected input.
 
-          [txtimeout-srv]: #txtimeout-srv
+#         [txtimeout-srv]: #txtimeout-srv
           [queryTxTimeout]: #queryTxTimeout
         x-desc-refs: |
           [txtimeout-srv]: admin.html#txtimeout-srv
@@ -896,13 +898,13 @@ definitions:
           [#use_cbo_req]
           Specifies whether the cost-based optimizer is enabled.
 
-          The [node-level][use-cbo-srv] `use-cbo` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting.
+#         The [node-level][use-cbo-srv] `use-cbo` setting specifies the default for this parameter for a single node.
+#         The request-level parameter overrides the node-level setting.
 
           In addition, the [cluster-level][queryUseCBO] `queryUseCBO` setting specifies the default for this parameter for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
-          [use-cbo-srv]: #use-cbo-srv
+#         [use-cbo-srv]: #use-cbo-srv
           [queryUseCBO]: #queryUseCBO
         x-desc-refs: |
           [use-cbo-srv]: admin.html#use-cbo-srv
@@ -946,9 +948,9 @@ definitions:
           * `unset` &mdash; read from replica is specified by the node-level setting.
           If the node-level setting is also `unset`, read from replica is disabled for this request.
 
-          The [node-level][use-replica-srv] `use-replica` setting specifies the default for this property for a single node.
-          The request-level parameter usually overrides the node-level setting.
-          However, when the node-level setting is `off`, the request-level parameter cannot enable the property.
+#         The [node-level][use-replica-srv] `use-replica` setting specifies the default for this property for a single node.
+#         The request-level parameter usually overrides the node-level setting.
+#         However, when the node-level setting is `off`, the request-level parameter cannot enable the property.
 
           In addition, the [cluster-level][queryUseReplica] `queryUseReplica` setting specifies the default for this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
@@ -961,7 +963,7 @@ definitions:
           Note that KV range scans cannot currently be started on a replica vBucket.
           If a query uses sequential scan and a data node becomes unavailable, the query might return an error, even if read from replica is enabled for the request.
 
-          [use-replica-srv]: #use-replica-srv
+#         [use-replica-srv]: #use-replica-srv
           [queryUseReplica]: #queryUseReplica
         x-desc-refs: |
           [use-replica-srv]: admin.html#use-replica-srv


### PR DESCRIPTION
Docs issue: DOC-10865

In the Server docs, the descriptions of the request-level settings are taken automatically from the Query Service REST API reference. I am assuming that, ultimately, the descriptions of request-level settings for Capella will be automatically generated from the Data API reference. However, the Data API is still in development.

As a temporary measure, this PR adds a cut-down version of the Query Service REST API to the (hitherto unused) `capella` branch of the cb-swagger docs, purely so that it can be used to generate descriptions of request-level settings for Capella.

Preview: [Configure Queries](https://ia.docs-test.couchbase.com/cloud/n1ql/n1ql-manage/query-settings.html)
Credentials: [Information Architecture changes](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Information-Architecture-changes)

⚠️ This change must be merged at the same time as the following related PRs:

* https://github.com/couchbaselabs/docs-devex/pull/216
* https://github.com/couchbase/docs-site/pull/758
* https://github.com/couchbasecloud/couchbase-cloud/pull/30942
