### PR TITLE
DOC-11231: IA Query Rework - Migrate Monitoring Queries page to Devex

### DIFF
--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -123,14 +123,39 @@ This property is only returned if a memory quota is set for the query.|integer
 |**node** +
 __optional__|IP address and port number of the node where the query is executed.|string
 |**phaseCounts** +
-__optional__|Count of documents processed at selective phases involved in the query execution.
-Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#profile[Attribute Profile in Query Response] for more details and examples.|object
+__optional__|Count of documents processed at selective phases involved in the query execution, such as authorize, index scan, fetch, parse, plan, run, etc.
+
+For active requests, this property is dynamic, depending on the documents processed by various phases up to this moment in time.
+Polling the active requests again may return different values. +
+**Example** : `{
+  "fetch" : 16,
+  "indexScan" : 187
+}`|object
 |**phaseOperators** +
-__optional__|Indicates the number of each kind of query operators involved in different phases of the query processing.
-Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#profile[Attribute Profile in Query Response] for more details and examples.|object
+__optional__|Indicates the numbers of each kind of query operator involved in different phases of the query processing.
+
+For instance, a non-covering index path might involve one index scan and one fetch operator.
+A join would probably involve two or more fetches, one per keyspace.
+A union select would have twice as many operator counts, one per each branch of the union. +
+**Example** : `{
+  "authorize" : 1,
+  "fetch" : 1,
+  "indexScan" : 2
+}`|object
 |**phaseTimes** +
-__optional__|Cumulative execution times for various phases involved in the query execution.
-Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#profile[Attribute Profile in Query Response] for more details and examples.|object
+__optional__|Cumulative execution times for various phases involved in the query execution, such as authorize, index scan, fetch, parse, plan, run, etc.
+
+For active requests, this property is dynamic, depending on the documents processed by various phases up to this moment in time.
+Polling the active requests again may return different values. +
+**Example** : `{
+  "authorize" : "823.631µs",
+  "fetch" : "656.873µs",
+  "indexScan" : "29.146543ms",
+  "instantiate" : "236.221µs",
+  "parse" : "826.382µs",
+  "plan" : "11.831101ms",
+  "run" : "16.892181ms"
+}`|object
 |**remoteAddr** +
 __optional__|IP address and port number of the client application, from where the query is received.|string
 |**requestId** +
@@ -223,6 +248,11 @@ It is only returned when retrieving a specific prepared statement, not when retr
 |**name** +
 __required__|The name of the prepared statement.
 This may be a UUID that was assigned automatically, or a name that was user-specified when the statement was created.|string
+|**namespace** +
+__optional__|The namespace in which the prepared statement is stored.
+Currently, only the `default` namespace is available.|string
+|**node** +
+__optional__|The node on which the prepared statement is stored.|string
 |**statement** +
 __required__|The text of the query.|string
 |**uses** +

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
@@ -668,6 +668,8 @@ __optional__|An array of 0 or more warning objects. If a warning occurred during
 __optional__|An object containing metrics about the request.|<<_metrics,Metrics>>
 |**controls** +
 __optional__|An object containing runtime information provided along with the request. Present only if `controls` was set to true in the <<_request_parameters,Request Parameters>>.|<<_controls,Controls>>
+|**profile** +
+__optional__|An object containing monitoring and profiling information about the request. Present only if `profile` was set to `&quot;phases&quot;` or `&quot;timings&quot;` in the <<_request_parameters,Request Parameters>>.|<<_profile,Profile>>
 |===
 
 
@@ -755,6 +757,114 @@ __optional__|The type of query statement. +
 
 Additional elements not listed here might also be present.
 Clients and consumers of the REST API or the logs must accommodate any additional elements.
+
+
+[[_profile]]
+=== Profile
+
+// tag::profile[]
+
+
+[options="header", cols=".^3a,.^11a,.^4a"]
+|===
+|Name|Description|Schema
+|**requestTime** +
+__required__|Timestamp when the query was received.|string (date-time)
+|**servicingHost** +
+__required__|IP address and port number of the node where the query was executed.|string
+|**phaseCounts** +
+__required__|Count of documents processed at selective phases involved in the query execution, such as authorize, index scan, fetch, parse, plan, run, etc. +
+**Example** : `{
+  "fetch" : 16,
+  "indexScan" : 187
+}`|object
+|**phaseOperators** +
+__required__|Indicates the numbers of each kind of query operator involved in different phases of the query processing.
+
+For instance, a non-covering index path might involve one index scan and one fetch operator.
+A join would probably involve two or more fetches, one per keyspace.
+A union select would have twice as many operator counts, one per each branch of the union.
+
+This is in essence the count of all the operators in the `executionTimings` object. +
+**Example** : `{
+  "authorize" : 1,
+  "fetch" : 1,
+  "indexScan" : 2
+}`|object
+|**phaseTimes** +
+__required__|Cumulative execution times for various phases involved in the query execution, such as authorize, index scan, fetch, parse, plan, run, etc. +
+**Example** : `{
+  "authorize" : "823.631µs",
+  "fetch" : "656.873µs",
+  "indexScan" : "29.146543ms",
+  "instantiate" : "236.221µs",
+  "parse" : "826.382µs",
+  "plan" : "11.831101ms",
+  "run" : "16.892181ms"
+}`|object
+|**executionTimings** +
+__optional__|Present only if `profile` was set to `&quot;timings&quot;` in the <<_request_parameters,Request Parameters>>.
+
+The execution details for various phases involved in the query execution, such as kernel and service execution times, number of documents processed at each query operator in each phase, and number of phase switches.|<<_execution_timings,Execution Timings>>
+|===
+
+[[_execution_timings]]
+**Execution Timings**
+
+[options="header", cols=".^3a,.^11a,.^4a"]
+|===
+|Name|Description|Schema
+|**#operator** +
+__required__|Name of the operator. +
+**Example** : `"Fetch"`|string
+|**#stats** +
+__required__|Statistics collected for the operator.|<<_statistics,Statistics>>
+|**~child** +
+__optional__|Further nested operators, each with their own execution timings.|object
+|===
+
+[[_statistics]]
+**Statistics**
+
+[options="header", cols=".^3a,.^11a,.^4a"]
+|===
+|Name|Description|Schema
+|**#itemsIn** +
+__optional__|Number of input documents to the operator. +
+**Example** : `187`|integer (int32)
+|**#itemsOut** +
+__optional__|Number of output documents after the operator processing. +
+**Example** : `16`|integer (int32)
+|**#phaseSwitches** +
+__optional__|Number of switches between executing, waiting for services, or waiting for the goroutine scheduler. +
+**Example** : `413`|integer (int32)
+|**execTime** +
+__optional__|Time spent executing the operator code inside SQL++ query engine. +
+**Example** : `"128.434µs"`|string (duration)
+|**kernTime** +
+__optional__|Time spent waiting to be scheduled for CPU time. +
+**Example** : `"15.027879ms"`|string (duration)
+|**servTime** +
+__optional__|Time spent waiting for another service, such as index or data.
+
+For index scan, it is time spent waiting for GSI/indexer.
+
+For fetch, it is time spent waiting on the KV store. +
+**Example** : `"1.590934ms"`|string (duration)
+|===
+
+
+[TIP]
+====
+The `kernTime`, `servTime`, and `execTime` statistics can be very helpful in troubleshooting query performance issues.
+For example:
+
+* A high `servTime` for a low number of items processed is an indication that the indexer or KV store is stressed.
+* A high `kernTime` means there is a downstream issue in the query plan or the query server having many requests to process, so the scheduled waiting time will be more for CPU time.
+====
+
+
+// end::profile[]
 
 
 

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -619,24 +619,46 @@ definitions:
       phaseCounts:
         type: object
         description: |
-          Count of documents processed at selective phases involved in the query execution.
-          Refer to [Attribute Profile in Query Response][profile] for more details and examples.
+          Count of documents processed at selective phases involved in the query execution, such as authorize, index scan, fetch, parse, plan, run, etc.
 
-          [profile]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#profile
+          For active requests, this property is dynamic, depending on the documents processed by various phases up to this moment in time.
+          Polling the active requests again may return different values.
+        example:
+          {
+            "fetch": 16,
+            "indexScan": 187
+          }
       phaseOperators:
         type: object
         description: |
-          Indicates the number of each kind of query operators involved in different phases of the query processing.
-          Refer to [Attribute Profile in Query Response][profile] for more details and examples.
+          Indicates the numbers of each kind of query operator involved in different phases of the query processing.
 
-          [profile]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#profile
+          For instance, a non-covering index path might involve one index scan and one fetch operator.
+          A join would probably involve two or more fetches, one per keyspace.
+          A union select would have twice as many operator counts, one per each branch of the union.
+        example:
+          {
+            "authorize": 1,
+            "fetch": 1,
+            "indexScan": 2
+          }
       phaseTimes:
         type: object
         description: |
-          Cumulative execution times for various phases involved in the query execution.
-          Refer to [Attribute Profile in Query Response][profile] for more details and examples.
+          Cumulative execution times for various phases involved in the query execution, such as authorize, index scan, fetch, parse, plan, run, etc.
 
-          [profile]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#profile
+          For active requests, this property is dynamic, depending on the documents processed by various phases up to this moment in time.
+          Polling the active requests again may return different values.
+        example:
+          {
+            "authorize": "823.631µs",
+            "fetch": "656.873µs",
+            "indexScan": "29.146543ms",
+            "instantiate": "236.221µs",
+            "parse": "826.382µs",
+            "plan": "11.831101ms",
+            "run": "16.892181ms"
+          }
       remoteAddr:
         type: string
         description: IP address and port number of the client application, from where the query is received.

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -715,6 +715,15 @@ definitions:
         description: |
           The name of the prepared statement.
           This may be a UUID that was assigned automatically, or a name that was user-specified when the statement was created.
+      namespace:
+        type: string
+        description: |
+          The namespace in which the prepared statement is stored.
+          Currently, only the `default` namespace is available.
+      node:
+        type: string
+        description: |
+          The node on which the prepared statement is stored.
       statement:
         type: string
         description: The text of the query.

--- a/src/query-service/extensions/dynamic/definitions/Profile/definition-begin-tag.adoc
+++ b/src/query-service/extensions/dynamic/definitions/Profile/definition-begin-tag.adoc
@@ -1,0 +1,1 @@
+// tag::profile[]

--- a/src/query-service/extensions/dynamic/definitions/Profile/definition-end-note.adoc
+++ b/src/query-service/extensions/dynamic/definitions/Profile/definition-end-note.adoc
@@ -1,0 +1,8 @@
+[TIP]
+====
+The `kernTime`, `servTime`, and `execTime` statistics can be very helpful in troubleshooting query performance issues.
+For example:
+
+* A high `servTime` for a low number of items processed is an indication that the indexer or KV store is stressed.
+* A high `kernTime` means there is a downstream issue in the query plan or the query server having many requests to process, so the scheduled waiting time will be more for CPU time.
+====

--- a/src/query-service/extensions/dynamic/definitions/Profile/definition-end-tag.adoc
+++ b/src/query-service/extensions/dynamic/definitions/Profile/definition-end-tag.adoc
@@ -1,0 +1,1 @@
+// end::profile[]

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -1058,6 +1058,12 @@ definitions:
           An object containing runtime information provided along with the request.
           Present only if `controls` was set to true in the [Request Parameters](#_request_parameters).
         $ref: "#/definitions/Controls"
+      profile:
+        type: object
+        description: >
+          An object containing monitoring and profiling information about the request.
+          Present only if `profile` was set to `"phases"` or `"timings"` in the [Request Parameters](#_request_parameters).
+        $ref: "#/definitions/Profile"
 
   Conditions:
     type: object
@@ -1173,6 +1179,120 @@ definitions:
         type: string
         description: The type of query statement.
         example: SELECT
+
+  Profile:
+    type: object
+    required:
+      - requestTime
+      - servicingHost
+      - phaseCounts
+      - phaseOperators
+      - phaseTimes
+    properties:
+      requestTime:
+        type: string
+        format: date-time
+        description: Timestamp when the query was received.
+      servicingHost:
+        type: string
+        description: IP address and port number of the node where the query was executed.
+      phaseCounts:
+        type: object
+        description: |
+          Count of documents processed at selective phases involved in the query execution, such as authorize, index scan, fetch, parse, plan, run, etc.
+        example:
+          {
+            "fetch": 16,
+            "indexScan": 187
+          }
+      phaseOperators:
+        type: object
+        description: |
+          Indicates the numbers of each kind of query operator involved in different phases of the query processing.
+
+          For instance, a non-covering index path might involve one index scan and one fetch operator.
+          A join would probably involved two or more fetches, one per keyspace.
+          A union select would have twice as many operator counts, one per each branch of the union.
+
+          This is in essence the count of all the operators in the `executionTimings` object.
+        example:
+          {
+            "authorize": 1,
+            "fetch": 1,
+            "indexScan": 2
+          }
+      phaseTimes:
+        type: object
+        description: |
+          Cumulative execution times for various phases involved in the query execution, such as authorize, index scan, fetch, parse, plan, run, etc.
+        example:
+          {
+            "authorize": "823.631µs",
+            "fetch": "656.873µs",
+            "indexScan": "29.146543ms",
+            "instantiate": "236.221µs",
+            "parse": "826.382µs",
+            "plan": "11.831101ms",
+            "run": "16.892181ms"
+          }
+      executionTimings:
+        type: object
+        title: Execution Timings
+        description: |
+          Present only if `profile` was set to `"timings"` in the [Request Parameters](#_request_parameters).
+
+          The execution details for various phases involved in the query execution, such as kernel and service execution times, number of documents processed at each query operator in each phase, and number of phase switches.
+        required:
+          - '#operator'
+          - '#stats'
+        properties:
+          '#operator':
+            type: string
+            description: Name of the operator.
+            example: Fetch
+          '#stats':
+            type: object
+            title: Statistics
+            description: Statistics collected for the operator.
+            properties:
+              '#itemsIn':
+                type: integer
+                format: int32
+                description: Number of input documents to the operator.
+                example: 187
+              '#itemsOut':
+                type: integer
+                format: int32
+                description: Number of output documents after the operator processing.
+                example: 16
+              '#phaseSwitches':
+                type: integer
+                format: int32
+                description: Number of switches between executing, waiting for services, or waiting for the goroutine scheduler.
+                example: 413
+              execTime:
+                type: string
+                format: duration
+                description: Time spent executing the operator code inside SQL++ query engine.
+                example: "128.434µs"
+              kernTime:
+                type: string
+                format: duration
+                description: Time spent waiting to be scheduled for CPU time.
+                example: "15.027879ms"
+              servTime:
+                type: string
+                format: duration
+                description: |
+                  Time spent waiting for another service, such as index or data.
+
+                  For index scan, it is time spent waiting for GSI/indexer.
+
+                  For fetch, it is time spent waiting on the KV store.
+                example: "1.590934ms"
+          '~child':
+            type: object
+            description: Further nested operators, each with their own execution timings.
 
 securityDefinitions:
   Header:

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -1211,7 +1211,7 @@ definitions:
           Indicates the numbers of each kind of query operator involved in different phases of the query processing.
 
           For instance, a non-covering index path might involve one index scan and one fetch operator.
-          A join would probably involved two or more fetches, one per keyspace.
+          A join would probably involve two or more fetches, one per keyspace.
           A union select would have twice as many operator counts, one per each branch of the union.
 
           This is in essence the count of all the operators in the `executionTimings` object.


### PR DESCRIPTION
Jira issue: DOC-11231

Adds extra details about profiling information that was previously detailed in the Managing and Monitoring Queries page.

Docs preview: [Query Service REST API › Profile](https://ia.docs-test.couchbase.com/server/current/n1ql/n1ql-rest-api/index.html#_profile), [Query Admin REST API › Requests](https://ia.docs-test.couchbase.com/server/current/n1ql/n1ql-rest-api/admin.html#_requests)
Credentials: [Information Architecture changes](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Information-Architecture-changes)

This PR should be merged at the same time as the following change:

* https://github.com/couchbaselabs/docs-devex/pull/221